### PR TITLE
CASMCMS-7645: Pin version of csm-ssh-keys-roles RPM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,11 @@
 
 FROM artifactory.algol60.net/registry.suse.com/suse/sle15:15.3 as product-content-base
 WORKDIR /
+
+# Pin the version of csm-ssh-keys being installed. The actual version is substituted by
+# the runBuildPrep script at build time
+ARG CSM_SSH_KEYS_VERSION=@RPM_VERSION@
+
 ARG SLES_MIRROR=https://slemaster.us.cray.com/SUSE
 ARG ARCH=x86_64
 RUN \
@@ -53,10 +58,12 @@ RUN \
   zypper --non-interactive clean &&\
   zypper --non-interactive --gpg-auto-import-keys refresh
 
-# Install dependencies as RPMs
+# Install csm-ssh-keys-roles RPM, and lock the version, just to be certain it is not
+# upgraded inadvertently somehow later
 RUN zypper ar --no-gpgcheck https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/ csm && \
     zypper refresh && \
-    zypper install -y csm-ssh-keys-roles==1.3.4
+    zypper in -f --no-confirm csm-ssh-keys-roles-${CSM_SSH_KEYS_VERSION} && \
+    zypper al csm-ssh-keys-roles
 
 # Apply security patches
 RUN zypper patch -y --with-update --with-optional

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,9 @@ all: runbuildprep lint image chart
 chart: chart_setup chart_package chart_test
 
 runbuildprep:
-		./cms_meta_tools/scripts/runBuildPrep.sh
+		# We call a local copy of runBuildPrep because we need to do some
+		# fancy footwork with the csm-ssh-keys version as well
+		./runBuildPrep.sh
 
 lint:
 		./cms_meta_tools/scripts/runLint.sh

--- a/runBuildPrep.sh
+++ b/runBuildPrep.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Copyright 2021 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# (MIT License)
+
+set -ex
+
+# First run update_external_versions to generate our csm-ssh-keys.version file
+# (and other files possibly, but that's the one we care about here)
+./cms_meta_tools/latest_version/update_external_versions.sh
+
+# Then before we run update_versions, we need to massage the csm-ssh-keys.version
+# file to convert it from a docker version to an RPM version
+# (i.e. strip off the build tag, if any, and append -1)
+sed -i 's/^\([0-9][0-9]*[.][0-9][0-9]*[.][0-9][0-9]*\).*$/\1-1/' csm-ssh-keys.version
+
+# Show the modified version
+cat csm-ssh-keys.version
+
+# And now we delete our update_external_versions.conf file, so that when
+# we call runBuildPrep.sh in cms_meta_tools it does not run a second time
+rm -v update_external_versions.conf
+
+# Finally, call the real runBuildPrep in cms_meta_tools:
+./cms_meta_tools/scripts/runBuildPrep.sh
+
+exit 0

--- a/update_external_versions.conf
+++ b/update_external_versions.conf
@@ -81,3 +81,14 @@
 image: cf-gitea-import
     major: 1
     minor: 4
+
+# We actually want the latest stable RPM version of csm-ssh-keys-roles, but that function is not yet
+# available in update_external_versions. Fortunately, however, we use the same version for
+# all artifacts in CMS repos (plus or minus the build tag that is appended to unstable docker
+# and helm charts). Because of this, we will get the latest stable csm-ssh-keys docker version,
+# and just strip off the build tag if one is present, and append "-1" to the end. That is the
+# latest stable RPM version.
+image: csm-ssh-keys
+    major: 1
+    minor: 3
+

--- a/update_versions.conf
+++ b/update_versions.conf
@@ -37,3 +37,7 @@ targetfile: kubernetes/csm-config/values.yaml
 sourcefile: cf-gitea-import.version
 tag: @CF_GITEA_IMPORT_VERSION@
 targetfile: Dockerfile
+
+sourcefile: csm-ssh-keys.version
+tag: @RPM_VERSION@
+targetfile: Dockerfile


### PR DESCRIPTION
This is the same as the recent PR to the ansible-execution-environment repo. Instead of having the Dockerfile install the absolute latest stable version of the csm-ssh-keys-roles RPM, this PR confines it to only considering the stable versions of that RPM which belong in the csm-1.2 release. No changes to any code logic, just a fix to the build logic.

I have verified that the build now picks up the latest stable csm-1.2 RPM for csm-ssh-keys-roles.