### PR TITLE
CASMINST-3525: rebuild for new version of cf-gitea-import

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # the repo. Unless a later match takes precedence, the
 # owners listed in this stanza will be requested for review
 # when someone opens a pull request.
-*       @Cray-HPE/cray-management-systems
+*       @Cray-HPE/CMS-core-CSM-product

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,8 +69,7 @@ COPY zypper-refresh-patch-clean.sh /
 RUN /zypper-refresh-patch-clean.sh && rm /zypper-refresh-patch-clean.sh
 
 # Use the cf-gitea-import as a base image with CSM content copied in
-#FROM artifactory.algol60.net/csm-docker/stable/cf-gitea-import:@CF_GITEA_IMPORT_VERSION@ as cf-gitea-import-base
-FROM artifactory.algol60.net/csm-docker/unstable/cf-gitea-import:0.3525.47-20211109201050_06b2fcd as cf-gitea-import-base
+FROM artifactory.algol60.net/csm-docker/stable/cf-gitea-import:@CF_GITEA_IMPORT_VERSION@ as cf-gitea-import-base
 
 WORKDIR /
 ENV CF_IMPORT_PRODUCT_NAME=csm

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,8 @@ COPY zypper-refresh-patch-clean.sh /
 RUN /zypper-refresh-patch-clean.sh && rm /zypper-refresh-patch-clean.sh
 
 # Use the cf-gitea-import as a base image with CSM content copied in
-FROM artifactory.algol60.net/csm-docker/stable/cf-gitea-import:@CF_GITEA_IMPORT_VERSION@ as cf-gitea-import-base
+#FROM artifactory.algol60.net/csm-docker/stable/cf-gitea-import:@CF_GITEA_IMPORT_VERSION@ as cf-gitea-import-base
+FROM artifactory.algol60.net/csm-docker/unstable/cf-gitea-import:0.3525.47-20211109201050_06b2fcd as cf-gitea-import-base
 
 WORKDIR /
 ENV CF_IMPORT_PRODUCT_NAME=csm


### PR DESCRIPTION
## Summary and Scope

Previously, when a branch already existed the was being pushed,
the import.py script used the Gitea API to enable pushes to the
repository after branches had been protected from a previous import.
When the branch does not change, ie a new version of CSM, but not a
new version of csm-import, a force push happens, but branch protections
that allow pushing on a protected branch do not allow force pushes.
To remedy this, instead of just enabling push, remove the branch
protections altogether, force push the branch, and then re-enable
branch protections if requested.

This is a backwards compatible change. We need to force this repo to rebuild to pick up the changes, so an update to the CODEOWNERS file (a non-deliverable fix) has been added to force the rebuild.

## Issues and Related PRs

* Resolves [CASMINST-3525](https://connect.us.cray.com/jira/browse/CASMINST-3525)
* Change will also be needed in `cf-gitea-import release/csm-1.0`, see https://github.com/Cray-HPE/cf-gitea-import/pull/3

## Testing

### Tested on:

  * `drax`

### Test description:

Rebuilt csm-config image/chart with this change and ran the chart on Drax. Successfully ran the new chart which attempted to force push the same branch. Code successfully removed branch protections, force pushed, and re-enabled branch protections.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? No
- Were continuous integration tests run? No
- Was upgrade tested? Yes
- Was downgrade tested? Yes
- Were new tests (or test issues/Jiras) created for this change? No

## Risks and Mitigations

N/A


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable