### PR TITLE
CASMTRIAGE-2815 Update list of CSM packages with new HMS test RPMs csm-1.2

### DIFF
--- a/ansible/vars/csm_packages.yml
+++ b/ansible/vars/csm_packages.yml
@@ -21,5 +21,17 @@
 # (MIT License)
 
 csm_sles_packages:
-  - hms-ct-test-crayctldeploy
   - cray-cmstools-crayctldeploy
+  - hms-bss-ct-test
+  - hms-capmc-ct-test
+  - hms-ct-test-base
+  - hms-fas-ct-test
+  - hms-hmcollector-ct-test
+  - hms-hbtd-ct-test
+  - hms-hmnfd-ct-test
+  - hms-meds-ct-test
+  - hms-reds-ct-test
+  - hms-rts-ct-test
+  - hms-scsd-ct-test
+  - hms-sls-ct-test
+  - hms-smd-ct-test


### PR DESCRIPTION
### Summary and Scope

This change removes the old HMS CT test RPM called **hms-ct-test-crayctldeploy** that has been replaced in csm-1.2 (and beyond) and adds the new HMS CT test RPMs to the list of Ansible CSM packages.

### Issues and Related PRs

* Resolves CASMTRIAGE-2815 in csm-1.2.

### Testing

Not sure how to test this, trying to fix "No provider of hms-ct-test-crayctldeploy" errors reported in CASMTRIAGE-2815 by the ansible-0 log as part of the CFS session.

Was a fresh Install tested? N
Was an Upgrade tested? N
Was a Downgrade tested? N

### Risks and Mitigations

Low risk, attempts to fix something that is currently broken.