### PR TITLE
Backport csm.packages to install loftsman in CSM 1.0.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ ARG ARCH=x86_64
 # upgraded inadvertently somehow later
 RUN zypper ar --no-gpgcheck https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/ csm && \
     zypper refresh && \
-	zypper in -f --no-confirm csm-ssh-keys-roles-${CSM_SSH_KEYS_VERSION} && \
+	zypper in -f --no-confirm csm-ssh-keys-roles-1.1.9-1 && \
 	zypper al csm-ssh-keys-roles
 
 # Apply security patches

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,9 +77,9 @@ ADD .version /product_version
 
 # Copy in dependencies' Ansible content
 COPY --from=product-content-base /opt/cray/ansible/roles/      /content/roles/
-#COPY --from=product-content-base /opt/cray/ansible/playbooks/ /content/playbooks/
 
 # Copy in CSM Ansible content
 COPY ansible/ /content/
 
 # Base image entrypoint takes it from here
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ ARG ARCH=x86_64
 # upgraded inadvertently somehow later
 RUN zypper ar --no-gpgcheck https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/ csm && \
     zypper refresh && \
-	zypper in -f --no-confirm csm-ssh-keys-roles-1.1.9-1 && \
+	zypper in -f --no-confirm csm-ssh-keys-roles-1.1.18-1 && \
 	zypper al csm-ssh-keys-roles
 
 # Apply security patches

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2021 Hewlett Packard Enterprise Development LP
+# Copyright 2021-2022 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -33,7 +33,7 @@ CHART_PATH ?= kubernetes
 CHART_NAME ?= $(NAME)
 
 CONFIG_IMAGE_NAME ?= $(NAME)
-CONFIG_IMAGE_TAG ?= $(CHART_VERSION)
+CONFIG_IMAGE_TAG ?= $(DOCKER_VERSION)
 
 HELM_UNITTEST_IMAGE ?= quintush/helm-unittest:3.3.0-0.2.5
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# (C) Copyright 2021 Hewlett Packard Enterprise Development LP
+# Copyright 2021 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -23,6 +23,7 @@
 # If you wish to perform a local build, you will need to clone or copy the contents of the
 # cms-meta-tools repo to ./cms_meta_tools
 
+# Docker Image
 NAME ?= csm-config
 DOCKER_VERSION ?= $(shell head -1 .docker_version)
 CHART_VERSION ?= $(shell head -1 .chart_version)

--- a/README.md
+++ b/README.md
@@ -32,17 +32,18 @@ When making a new release branch:
     * If an `update_external_versions.conf` file exists in this repo, be sure to update that as well, if needed.
 
 ## Copyright and License
-This project is copyrighted by Hewlett Packard Enterprise Development LP and is under the MIT
-license. See the [LICENSE](LICENSE) file for details.
+This project is copyrighted by Hewlett Packard Enterprise Development LP and is
+under the MIT license. See the [LICENSE](LICENSE) file for details.
 
-When making any modifications to a file that has a Cray/HPE copyright header, that header
-must be updated to include the current year.
+When making any modifications to a file that has a Cray/HPE copyright header,
+that header must be updated to include the current year.
 
-When creating any new files in this repo, if they contain source code, they must have
-the HPE copyright and license text in their header, unless the file is covered under
-someone else's copyright/license (in which case that should be in the header). For this
-purpose, source code files include Dockerfiles, Ansible files, RPM spec files, and shell
-scripts. It does **not** include Jenkinsfiles, OpenAPI/Swagger specs, or READMEs.
+When creating any new files in this repo, if they contain source code, they must
+have the HPE copyright and license text in their header, unless the file is
+covered under someone else's copyright/license (in which case that should be in
+the header). For this purpose, source code files include Dockerfiles, Ansible
+files, RPM spec files, and shell scripts. It does **not** include Jenkinsfiles,
+OpenAPI/Swagger specs, or READMEs.
 
-When in doubt, provided the file is not covered under someone else's copyright or license, then
-it does not hurt to add ours to the header.
+When in doubt, provided the file is not covered under someone else's copyright
+or license, then it does not hurt to add the HPE copyright to the header.

--- a/ansible/ncn-master_nodes.yml
+++ b/ansible/ncn-master_nodes.yml
@@ -1,5 +1,5 @@
 #!/usr/bin/env ansible-playbook
-# Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# Copyright 2021 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -21,7 +21,27 @@
 #
 # (MIT License)
 
-# Top-level site.yml for CSM Deployed Environments (NCNs, except for UANs)
-- import_playbook: ncn-master_nodes.yml
-- import_playbook: ncn-worker_nodes.yml
-- import_playbook: ncn-storage_nodes.yml
+# NCN Master Nodes Play
+- hosts: Management_Master
+  gather_facts: yes
+  any_errors_fatal: true
+  remote_user: root
+  vars_files:
+    - vars/csm_repos.yml
+    - vars/csm_packages.yml
+
+  roles:
+    # Allow trust of CSM generated keys for elective passwordless SSH;
+    # Enables both passwordless ssh from, and to, all nodes.
+    - role: trust-csm-ssh-keys
+    - role: passwordless-ssh
+
+    # Install CSM repositories and packages
+    - role: csm.packages
+
+    # Set the root password from the value stored in cray-vault
+    - role: csm.password
+      vars:
+        password_vault_secret: 'secret/csm/management_nodes'
+        password_vault_secret_key: 'root_password'
+        password_username: 'root'

--- a/ansible/ncn-storage_nodes.yml
+++ b/ansible/ncn-storage_nodes.yml
@@ -1,5 +1,5 @@
 #!/usr/bin/env ansible-playbook
-# Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# Copyright 2021 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -21,7 +21,27 @@
 #
 # (MIT License)
 
-# Top-level site.yml for CSM Deployed Environments (NCNs, except for UANs)
-- import_playbook: ncn-master_nodes.yml
-- import_playbook: ncn-worker_nodes.yml
-- import_playbook: ncn-storage_nodes.yml
+# NCN Storage Nodes Play
+- hosts: Management_Storage
+  gather_facts: yes
+  any_errors_fatal: true
+  remote_user: root
+  vars_files:
+    - vars/csm_repos.yml
+    - vars/csm_packages.yml
+
+  roles:
+    # Allow trust of CSM generated keys for elective passwordless SSH;
+    # Enables both passwordless ssh from, and to, all nodes.
+    - role: trust-csm-ssh-keys
+    - role: passwordless-ssh
+
+    # Install CSM repositories and packages
+    - role: csm.packages
+
+    # Set the root password from the value stored in cray-vault
+    - role: csm.password
+      vars:
+        password_vault_secret: 'secret/csm/management_nodes'
+        password_vault_secret_key: 'root_password'
+        password_username: 'root'

--- a/ansible/ncn-worker_nodes.yml
+++ b/ansible/ncn-worker_nodes.yml
@@ -1,5 +1,5 @@
 #!/usr/bin/env ansible-playbook
-# Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# Copyright 2021 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -21,7 +21,27 @@
 #
 # (MIT License)
 
-# Top-level site.yml for CSM Deployed Environments (NCNs, except for UANs)
-- import_playbook: ncn-master_nodes.yml
-- import_playbook: ncn-worker_nodes.yml
-- import_playbook: ncn-storage_nodes.yml
+# NCN Worker Nodes Play
+- hosts: Management_Worker
+  gather_facts: yes
+  any_errors_fatal: true
+  remote_user: root
+  vars_files:
+    - vars/csm_repos.yml
+    - vars/csm_packages.yml
+
+  roles:
+    # Allow trust of CSM generated keys for elective passwordless SSH;
+    # Enables both passwordless ssh from, and to, all nodes.
+    - role: trust-csm-ssh-keys
+    - role: passwordless-ssh
+
+    # Install CSM repositories and packages
+    - role: csm.packages
+
+    # Set the root password from the value stored in cray-vault
+    - role: csm.password
+      vars:
+        password_vault_secret: 'secret/csm/management_nodes'
+        password_vault_secret_key: 'root_password'
+        password_username: 'root'

--- a/ansible/packages.yml
+++ b/ansible/packages.yml
@@ -1,5 +1,5 @@
 #!/usr/bin/env ansible-playbook
-# Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# Copyright 2021 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -21,7 +21,16 @@
 #
 # (MIT License)
 
-# Top-level site.yml for CSM Deployed Environments (NCNs, except for UANs)
-- import_playbook: ncn-master_nodes.yml
-- import_playbook: ncn-worker_nodes.yml
-- import_playbook: ncn-storage_nodes.yml
+# CSM Repositories and Packages top-level Play
+- hosts: Management
+  gather_facts: yes
+  any_errors_fatal: true
+  remote_user: root
+  vars_files:
+    - vars/csm_repos.yml
+    - vars/csm_packages.yml
+
+  roles:
+
+    # Install CSM repositories and packages
+    - role: csm.packages

--- a/ansible/roles/csm.gpg_keys/README.md
+++ b/ansible/roles/csm.gpg_keys/README.md
@@ -1,0 +1,53 @@
+csm.gpg_keys
+=========
+
+Install the CSM GPG signing public key. This role is a dependency of the
+`csm.packages` role.
+
+Requirements
+------------
+
+The Kubernetes secret must be available in the namespace and field specified
+by the `csm_gpg_key_*` variables below. The key must be stored as a base64-encoded
+string.
+
+Role Variables
+--------------
+
+Available variables are listed below, along with default values (located in
+`defaults/main.yml`):
+
+    csm_gpg_key_k8s_secret: "hpe-signing-key"
+
+The Kubernetes secret which contains the GPG public key.
+
+    csm_gpg_key_k8s_namespace: "services"
+
+The Kubernetes namespace which contains the secret.
+
+    csm_gpg_key_k8s_field: "gpg-pubkey"
+
+The field in the Kubernetes secret that holds the GPG public key.
+
+Dependencies
+------------
+
+None.
+
+Example Playbook
+----------------
+
+    - hosts: Management_Master
+      roles:
+         - role: csm.gpg_key
+
+
+License
+-------
+
+MIT
+
+Author Information
+------------------
+
+Copyright 2021 Hewlett Packard Enterprise Development LP

--- a/ansible/roles/csm.gpg_keys/defaults/main.yml
+++ b/ansible/roles/csm.gpg_keys/defaults/main.yml
@@ -1,5 +1,4 @@
-#!/usr/bin/env ansible-playbook
-# Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# Copyright 2021 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -21,7 +20,7 @@
 #
 # (MIT License)
 
-# Top-level site.yml for CSM Deployed Environments (NCNs, except for UANs)
-- import_playbook: ncn-master_nodes.yml
-- import_playbook: ncn-worker_nodes.yml
-- import_playbook: ncn-storage_nodes.yml
+# Defaults for the csm.gpg_key role. See the README.md for information.
+csm_gpg_key_k8s_secret: "hpe-signing-key"
+csm_gpg_key_k8s_namespace: "services"
+csm_gpg_key_k8s_field: "gpg-pubkey"

--- a/ansible/roles/csm.gpg_keys/meta/main.yml
+++ b/ansible/roles/csm.gpg_keys/meta/main.yml
@@ -1,5 +1,4 @@
-#!/usr/bin/env ansible-playbook
-# Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# Copyright 2021 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -20,8 +19,17 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 # (MIT License)
+---
+dependencies: []
 
-# Top-level site.yml for CSM Deployed Environments (NCNs, except for UANs)
-- import_playbook: ncn-master_nodes.yml
-- import_playbook: ncn-worker_nodes.yml
-- import_playbook: ncn-storage_nodes.yml
+galaxy_info:
+  role_name: csm.gpg_key
+  author: randy.kleinman@hpe.com
+  description: Cray System Management (CSM) GPG Key Setup
+  company: "Hewlett Packard Enterprise Development LP"
+  license: "MIT"
+  min_ansible_version: 2.9
+  platforms: []
+  galaxy_tags:
+    - system
+    - hpc

--- a/ansible/roles/csm.gpg_keys/tasks/main.yml
+++ b/ansible/roles/csm.gpg_keys/tasks/main.yml
@@ -1,5 +1,4 @@
-#!/usr/bin/env ansible-playbook
-# Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# Copyright 2021 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -21,7 +20,29 @@
 #
 # (MIT License)
 
-# Top-level site.yml for CSM Deployed Environments (NCNs, except for UANs)
-- import_playbook: ncn-master_nodes.yml
-- import_playbook: ncn-worker_nodes.yml
-- import_playbook: ncn-storage_nodes.yml
+# Tasks for the csm.gpg_keys role
+- name: Fetch the HPE GPG Signing Key from the K8S secret
+  no_log: true
+  local_action:
+    module: csm_read_secret
+    name: "{{ csm_gpg_key_k8s_secret }}"
+    namespace: "{{ csm_gpg_key_k8s_namespace }}"
+    key: "{{ csm_gpg_key_k8s_field }}"
+    decrypt: True
+  register: hpe_gpg_pubkey
+
+- name: Create a temporary file to store the key content
+  tempfile:
+    state: file
+    suffix: key
+  register: temp_key_file
+
+- name: Copy the key content to a temporary file
+  copy:
+    content: "{{ hpe_gpg_pubkey.response }}"
+    dest: "{{ temp_key_file.path }}"
+
+- name: Install the HPE Signing Key
+  rpm_key:
+    state: present
+    key: "{{ temp_key_file.path }}"

--- a/ansible/roles/csm.packages/README.md
+++ b/ansible/roles/csm.packages/README.md
@@ -1,0 +1,60 @@
+csm.packages
+=========
+
+Install CSM RPM repositories and packages.
+
+
+Requirements
+------------
+
+None.
+
+Role Variables
+--------------
+
+Available variables are listed below, along with default values (located in
+`defaults/main.yml`):
+
+    csm_sles_repositories: {}
+
+List of SUSE Linux Enterprise Server repositories to install. See example below
+for mapping keys. These keys are directly used with the Ansible `zypper_repository`
+module. The `name`, `description`, `repo`, and `disable_gpg_check` fields are
+supported.
+
+    csm_sles_packages: []
+
+List of packages to install.
+
+Dependencies
+------------
+
+Requires the `csm.gpg_keys` role to be run to add the HPE GPG signing key to a
+host's RPM database if the repository GPG checks are enabled (they are by
+default, i.e. `disable_gpg_check: no`).
+
+Example Playbook
+----------------
+
+    - hosts: Management_Master
+      roles:
+         - role: csm.packages
+           vars:
+             csm_sles_packages:
+               - foo
+               - bar
+             csm_sles_repositories:
+               - name: CSM SLE 15 SP2
+                 description: CSM SUSE Linux Enterprise 15 SP2 Packages
+                 repo: https://packages.local/repositories/csm-sle-15sp2
+                 disable_gpg_check: no
+
+License
+-------
+
+MIT
+
+Author Information
+------------------
+
+Copyright 2021 Hewlett Packard Enterprise Development LP

--- a/ansible/roles/csm.packages/defaults/main.yml
+++ b/ansible/roles/csm.packages/defaults/main.yml
@@ -1,5 +1,4 @@
-#!/usr/bin/env ansible-playbook
-# Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# Copyright 2021 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -21,7 +20,7 @@
 #
 # (MIT License)
 
-# Top-level site.yml for CSM Deployed Environments (NCNs, except for UANs)
-- import_playbook: ncn-master_nodes.yml
-- import_playbook: ncn-worker_nodes.yml
-- import_playbook: ncn-storage_nodes.yml
+# Defaults for the csm.packages role. See the README.md for information.
+csm_sles_packages: []
+csm_sles_repositories: {}
+

--- a/ansible/roles/csm.packages/meta/main.yml
+++ b/ansible/roles/csm.packages/meta/main.yml
@@ -1,5 +1,4 @@
-#!/usr/bin/env ansible-playbook
-# Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# Copyright 2021 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -20,8 +19,18 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 # (MIT License)
+---
+dependencies:
+  - csm.gpg_keys
 
-# Top-level site.yml for CSM Deployed Environments (NCNs, except for UANs)
-- import_playbook: ncn-master_nodes.yml
-- import_playbook: ncn-worker_nodes.yml
-- import_playbook: ncn-storage_nodes.yml
+galaxy_info:
+  role_name: csm.packages
+  author: randy.kleinman@hpe.com
+  description: Cray System Management (CSM) RPM Repository Setup and Package Installation
+  company: "Hewlett Packard Enterprise Development LP"
+  license: "MIT"
+  min_ansible_version: 2.9
+  platforms: []
+  galaxy_tags:
+    - system
+    - hpc

--- a/ansible/roles/csm.packages/tasks/main.yml
+++ b/ansible/roles/csm.packages/tasks/main.yml
@@ -1,5 +1,4 @@
-#!/usr/bin/env ansible-playbook
-# Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# Copyright 2021 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -21,7 +20,31 @@
 #
 # (MIT License)
 
-# Top-level site.yml for CSM Deployed Environments (NCNs, except for UANs)
-- import_playbook: ncn-master_nodes.yml
-- import_playbook: ncn-worker_nodes.yml
-- import_playbook: ncn-storage_nodes.yml
+# Tasks for the csm.packages role
+- name: Configure CSM RPM Repos (SLES-based)
+  zypper_repository:
+    name: "{{ item.name }}"
+    description: "{{ item.description }}"
+    repo: "{{ item.repo }}"
+    state: present
+    disable_gpg_check: "{{ item.disable_gpg_check | default('no') }}"
+  when: ansible_os_family == "SLE_HPC"
+  loop: "{{ csm_sles_repositories }}"
+
+# CSM repos are generated during the release distribution creation and
+# therefore repo metadata is not signed. Allow for the repo metadata to be
+# unsigned, but still check the signature on individual packages.
+- name: Allow unsigned repo metadata
+  command: "zypper modifyrepo --gpgcheck-allow-unsigned-repo {{ item.name }}"
+  args:
+    warn: no  # Ansible's Zypper module does not provide this feature
+  loop: "{{ csm_sles_repositories }}"
+  when: ansible_os_family == "SLE_HPC"
+
+- name: Install RPMs (SLES-based)
+  zypper:
+    name: "{{ csm_sles_packages }}"
+    state: latest
+    update_cache: yes
+  when: ansible_os_family == "SLE_HPC"
+

--- a/ansible/vars/csm_packages.yml
+++ b/ansible/vars/csm_packages.yml
@@ -1,4 +1,4 @@
-# Copyright 2021 Hewlett Packard Enterprise Development LP
+# Copyright 2021-2022 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/ansible/vars/csm_packages.yml
+++ b/ansible/vars/csm_packages.yml
@@ -23,3 +23,4 @@
 csm_sles_packages:
   - hms-ct-test-crayctldeploy
   - cray-cmstools-crayctldeploy
+  - loftsman

--- a/ansible/vars/csm_packages.yml
+++ b/ansible/vars/csm_packages.yml
@@ -1,5 +1,4 @@
-#!/usr/bin/env ansible-playbook
-# Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# Copyright 2021 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -21,7 +20,6 @@
 #
 # (MIT License)
 
-# Top-level site.yml for CSM Deployed Environments (NCNs, except for UANs)
-- import_playbook: ncn-master_nodes.yml
-- import_playbook: ncn-worker_nodes.yml
-- import_playbook: ncn-storage_nodes.yml
+csm_sles_packages:
+  - hms-ct-test-crayctldeploy
+  - cray-cmstools-crayctldeploy

--- a/ansible/vars/csm_repos.yml
+++ b/ansible/vars/csm_repos.yml
@@ -1,5 +1,4 @@
-#!/usr/bin/env ansible-playbook
-# Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# Copyright 2021 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -21,7 +20,8 @@
 #
 # (MIT License)
 
-# Top-level site.yml for CSM Deployed Environments (NCNs, except for UANs)
-- import_playbook: ncn-master_nodes.yml
-- import_playbook: ncn-worker_nodes.yml
-- import_playbook: ncn-storage_nodes.yml
+csm_sles_repositories:
+- name: csm-sle-15sp2
+  description: "CSM SLE 15 SP2 Packages (added by Ansible)"
+  repo: https://packages.local/repository/csm-sle-15sp2
+

--- a/kubernetes/csm-config/Chart.yaml
+++ b/kubernetes/csm-config/Chart.yaml
@@ -6,8 +6,12 @@ version: @product_version@
 keywords:
   - csm
   - cfs
+  - ansible
 sources:
   - "https://github.com/Cray-HPE/csm-config"
 maintainers:
   - name: jsl
     email: joel.landsteiner@hpe.com
+  - name: rkleinman
+    email: randy.kleinman@hpe.com
+

--- a/kubernetes/csm-config/values.yaml
+++ b/kubernetes/csm-config/values.yaml
@@ -4,11 +4,11 @@
 # For products that import Ansible configuration content
 cray-import-config:
   config_image:
-    name: "@config_image_name@"
+    name: csm-config
     tag: "@config_image_tag@"
 
   import_job:
-    CF_IMPORT_PRODUCT_NAME: "@product_name@"
+    CF_IMPORT_PRODUCT_NAME: "csm"
     CF_IMPORT_PRODUCT_VERSION: "@product_version@"
-    CF_IMPORT_GITEA_REPO: "@product_name@-config-management"
+    CF_IMPORT_GITEA_REPO: "csm-config-management"
 

--- a/runLint.sh
+++ b/runLint.sh
@@ -1,4 +1,5 @@
-#!/usr/bin/env ansible-playbook
+#!/bin/bash
+
 # Copyright 2020-2021 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
@@ -21,7 +22,9 @@
 #
 # (MIT License)
 
-# Top-level site.yml for CSM Deployed Environments (NCNs, except for UANs)
-- import_playbook: ncn-master_nodes.yml
-- import_playbook: ncn-worker_nodes.yml
-- import_playbook: ncn-storage_nodes.yml
+./install_cms_meta_tools.sh || exit 1
+RC=0
+./cms_meta_tools/scripts/runLint.sh || RC=1
+rm -rf ./cms_meta_tools
+exit $RC
+

--- a/update_versions.conf
+++ b/update_versions.conf
@@ -20,6 +20,9 @@
 sourcefile: .chart_version
 tag: @product_version@
 targetfile: kubernetes/csm-config/Chart.yaml
+
+sourcefile: .docker_version
+tag: @product_version@
 targetfile: kubernetes/csm-config/values.yaml
 
 # The following file does not exist in the repo as a static file


### PR DESCRIPTION
## Summary and Scope

This is a backwards-compatible backport to bring in the `csm.packages` functionality that was introduced in CSM 1.2.

Note that we have not formally backported the `csm_read_secrets` module from the csm-ssh-keys repository as this will require rebuilds and manifest updates for AEE, CFS Operator, and this repository and building a new RPM in that repo could affect other product teams which have not pinned their version of the csm-ssh-keys RPM. Instead, we have included the `files/csm_read_secrets_backport.py` script to mimic the functionality of the CSM 1.2 version of the module. This change is encapsulated in 64a0cdb304260b388edc22a4e043274c9ba09f29.



## Issues and Related PRs

* Resolves [CASMINST-3664](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3664)
* Change will also be needed in the CSM manifest

## Testing

### Tested on:

  * `fanta`

### Test description:

1. Installed loftsman RPM to a new nexus repo 
2. Installed chart on system to import CSM Ansible into gitea.
3. Added new repo to Ansible configuration.
4. Ran NCN personalization on the master nodes.
5. Verified new loftsman RPM was installed.

```bash
ncn-m001:~/rkleinman # rpm -qa | grep loftsman
loftsman-1.2.0-1.x86_64
```

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? No
- Were continuous integration tests run? If not, why? N/A
- Was upgrade tested? If not, why? Yes
- Was downgrade tested? If not, why? Yes
- Were new tests (or test issues/Jiras) created for this change? N/A

## Risks and Mitigations

End-around backport is non-standard, but shouldn't be a huge deal.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [N/A] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [N/A] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

