### PR TITLE
Enable the cronjob kicker on new master node

### DIFF
--- a/ansible/roles/csm.ncn.move_first_master/tasks/main.yml
+++ b/ansible/roles/csm.ncn.move_first_master/tasks/main.yml
@@ -136,6 +136,28 @@
     job: "/srv/cray/scripts/kubernetes/token-certs-refresh.sh >> /var/log/cray/cron.log 2>&1"
     cron_file: cray-k8s-token-certs-refresh
 
+- name: Copy the cronjob kicker script into /usr/bin
+  when:
+    - first_master_hostname == target_hostname
+  delegate_to: "{{ new_first_master_hostname }}"
+  copy:
+    remote_src: yes
+    src: /srv/cray/resources/common/cronjob_kicker.py
+    dest: /usr/bin/cronjob_kicker.py
+    mode: 0755
+
+- name: Setup cron to run cronjob kicker script
+  when:
+    - first_master_hostname == target_hostname
+  delegate_to: "{{ new_first_master_hostname }}"
+  cron:
+    name: cray-k8s-cronjob-kicker
+    minute: 0
+    hour: "*/2"
+    user: root
+    job: "KUBECONFIG=/etc/kubernetes/admin.conf /usr/bin/cronjob_kicker.py"
+    cron_file: cray-k8s-cronjob-kicker
+
 #- name: Set new first master in BSS global cloud-init metadata
 #  when:
 #    - first_master_hostname == target_hostname


### PR DESCRIPTION
## Issues and Related PRs

* Resolves [CASMINST-3792](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3792)

## Testing

Minimal testing of the ansible (craystack).

### Tested on:

  * `craystack`

### Test description:

Ran the ansible in isolation to make sure i've used cron and copy modules correctly.

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
C02YT3JRLVCJ:node-image-build bklein$ vim /tmp/foo
C02YT3JRLVCJ:node-image-build bklein$ cat /tmp/foo
(1.2): https://github.com/Cray-HPE/csm-config/pull/38
(master):

## Summary and Scope

When promoting a new first master, we also need to enable the cronjob kicker script in cron.

## Issues and Related PRs

* Resolves [CASMINST-3792](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3792)

## Testing

Minimal testing of the ansible (craystack).

### Tested on:

  * `craystack`

### Test description:

Ran the ansible in isolation to make sure i've used cron and copy modules correctly.

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable