### PR TITLE
CASMINST-3811: Add loftsman to csm_packages

### DIFF
--- a/ansible/vars/csm_packages.yml
+++ b/ansible/vars/csm_packages.yml
@@ -35,3 +35,5 @@ csm_sles_packages:
   - hms-scsd-ct-test
   - hms-sls-ct-test
   - hms-smd-ct-test
+  - loftsman
+


### PR DESCRIPTION
## Summary and Scope

Add loftsman to the list of packages to install/upgrade during
Management node configuration/NCN personalization. Loftsman
needed to be upgraded in the CSM 1.0.10 release, and in order to
ensure that the latest version gets upgraded on future releases
and patches, add loftsman to future proof it.

Backwards compatible change.

## Issues and Related PRs

* Resolves CASMINST-3811

## Testing

This was tested in CASMINST-3664 (version 1.6.28 of csm-config).

## Risks and Mitigations

Low, typically loftsman will be installed in the NCN image as the latest version.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

