### PR TITLE
CASMINST-4145 - Include updated version of cf-gitea-import to resolve CVEs.

### DIFF
--- a/update_external_versions.conf
+++ b/update_external_versions.conf
@@ -80,7 +80,7 @@
 
 image: cf-gitea-import
     major: 1
-    minor: 4
+    minor: 5
 
 # We actually want the latest stable RPM version of csm-ssh-keys-roles, but that function is not yet
 # available in update_external_versions. Fortunately, however, we use the same version for


### PR DESCRIPTION
## Summary and Scope

We needed to update the version of alpine that cf-gitea-import was using to resolve CVE vulnerabilities.  This rebuild pulls in the new base image.

## Issues and Related PRs
* Resolves [CASMINST-4145](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4145)

## Testing
### Tested on:
  * `Drax`
  * Local development environment

### Test description:

After the new image was built, I used snyk to insure the updated image was free of vulnerabilities.  We installed the new image on Drax and insured that the gitea import worked correctly.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is a low risk change as it just updates the alpine base image that our container is based on.  There are no changes to our code or functionality.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable

