### PR TITLE
CASMCMS-7890

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,16 +67,3 @@ When making a new release branch:
 This project is copyrighted by Hewlett Packard Enterprise Development LP and is
 under the MIT license. See the [LICENSE](LICENSE) file for details.
 
-When making any modifications to a file that has a Cray/HPE copyright header,
-that header must be updated to include the current year.
-
-When creating any new files in this repo, if they contain source code, they must
-have the HPE copyright and license text in their header, unless the file is
-covered under someone else's copyright/license (in which case that should be in
-the header). For this purpose, source code files include Dockerfiles, Ansible
-files, RPM spec files, and shell scripts. It does **not** include Jenkinsfiles,
-OpenAPI/Swagger specs, or READMEs.
-
-When in doubt, provided the file is not covered under someone else's copyright
-or license, then it does not hurt to add the HPE copyright to the header.
-

--- a/kubernetes/csm-config/Chart.yaml
+++ b/kubernetes/csm-config/Chart.yaml
@@ -1,3 +1,26 @@
+#
+# MIT License
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 apiVersion: v2
 name: "csm-config"
 version: 0.0.0-chart
@@ -10,7 +33,7 @@ sources:
   - "https://github.com/Cray-HPE/csm-config"
 dependencies:
 - name: cray-import-config
-  version: ^2.0.0
+  version: ^3.0.0
   repository: https://artifactory.algol60.net/artifactory/csm-helm-charts/
 maintainers:
   - name: jsl-hpe

--- a/update_external_versions.conf
+++ b/update_external_versions.conf
@@ -80,7 +80,7 @@
 
 image: cf-gitea-import
     major: 1
-    minor: 5
+    minor: 6
 
 # We actually want the latest stable RPM version of csm-ssh-keys-roles, but that function is not yet
 # available in update_external_versions. Fortunately, however, we use the same version for


### PR DESCRIPTION
## Summary and Scope

Bring in the new cf-gitea-import v1.6.0 and cray-import-config v3.0.3 base chart to fix CASMCMS-7890. The csm-config chart will now retain the same commit id when a chart is re-run with the same product version. This will remove the need for users to update their CSM configuration layer commit id in CFS despite having the same content.

## Issues and Related PRs

* Resolves CASMCMS-7890

## Testing

### Tested on:

  * `mug`

### Test description:

Ran csm-config chart with loftsman changing the chart version and leaving the product version the same. Verified in the product catalog that the commit was unchanged by default, and changed when `CF_IMPORT_FORCE_EXISTING_BRANCH` was specified.

## Risks and Mitigations

No

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
