### PR TITLE
CASMCMS-7990: Append newline to SSH key files

### DIFF
--- a/ansible/roles/csm.ssh_keys/tasks/main.yml
+++ b/ansible/roles/csm.ssh_keys/tasks/main.yml
@@ -88,9 +88,15 @@
     state: present
   when: ssh_pub_key != ''
 
+# A newline is appended to the file contents for both files. If the file does not end with a newline, SSH considers
+# it to be in an invalid format. Additional superfluous newlines do not cause a problem. Therefore, we append a newline
+# to both SSH key files, because:
+# 1. There is no reason an administrator would want to populate their SSH key files with an invalid format, and
+# 2. We have seen cases where users accidentally omit the trailing newline when putting these values in Vault.
+
 - name: Copy the public key
   copy:
-    content: "{{ ssh_pub_key }}"
+    content: "{{ ssh_pub_key }}\n"
     dest: "{{ user_registered.home }}/.ssh/id_{{ ssh_keys_keytype }}.pub"
     mode: 0644
   become: true
@@ -100,7 +106,7 @@
 - name: Copy the private key
   no_log: true
   copy:
-    content: "{{ ssh_priv_key }}"
+    content: "{{ ssh_priv_key }}\n"
     dest: "{{ user_registered.home }}/.ssh/id_{{ ssh_keys_keytype }}"
     mode: 0600
   become: true


### PR DESCRIPTION
## Summary and Scope

We have seen at least a couple of installs where SSH was broken between NCNs after NCN personalization was run. The cause was that no newline was present at the end of the SSH key files, which causes SSH to view the files as being in an invalid format. The lack of a trailing newline was because the key values were stored in vault with no ending newline. This was done due to user error (or user unawareness that it mattered).

I have discovered that having extra newlines at the end of the file is not a problem, however. So I propose to modify the Ansible play so that it adds a newline at the end of the files. Worst case it is superfluous, but in the case that the user omitted it, this would correct the problem. I can see no reason why a user would deliberately want their SSH key files to be in an invalid format.

## Issues and Related PRs

* Would have prevented problem reported in [CASMTRIAGE-3230](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3230)
* [CASMINST-4475](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4475) is open to improve the docs for this part of the install, and hopefully that will reduce the likelihood of user error, but it we can avoid this problem entirely with a small code change, it still seems good to do.

## Testing

I tested this on drax, but only by making the change locally on VCS, not by deploying an updated csm-config artifact. I will do the artifact testing as well, but figured in the meantime I'd open this up for review.

## Risks and Mitigations

Low risk, provided the testing continues to go well. The change is very small.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable

