### PR TITLE
CASMNET-1528 - BI-CAN: Create CFS play that will setup CHN IP on NCNs after HSN install

### DIFF
--- a/ansible/enable_chn.yml
+++ b/ansible/enable_chn.yml
@@ -1,5 +1,8 @@
 #!/usr/bin/env ansible-playbook
-# Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+#
+# MIT License
+#
+# (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -13,13 +16,12 @@
 #
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
 # THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
 # OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-# (MIT License)
 - hosts: Management_Worker
   gather_facts: yes
   any_errors_fatal: true

--- a/ansible/enable_chn.yml
+++ b/ansible/enable_chn.yml
@@ -1,0 +1,29 @@
+#!/usr/bin/env ansible-playbook
+# Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# (MIT License)
+- hosts: Management_Worker
+  gather_facts: yes
+  any_errors_fatal: true
+  remote_user: root
+
+  roles:
+    - role: csm.ncn.enable_chn

--- a/ansible/roles/csm.ncn.enable_chn/README.md
+++ b/ansible/roles/csm.ncn.enable_chn/README.md
@@ -1,0 +1,41 @@
+csm.ncn.enable_chn
+==================
+
+Configure the Customer Highspeed Network (CHN) IP addresses on worker nodes if applicable.
+
+Requirements
+------------
+
+The system has been configured with CHN and it has been activated by setting it as the SystemDefaultRoute in the SLS BICAN network definition.
+
+Role Variables
+--------------
+
+Available variables are listed below, along with default values (located in
+`defaults/main.yml`):
+
+    chn_interface: hsn0
+
+The HSN interface to be used for the CHN.
+
+Dependencies
+------------
+
+None.
+
+Example Playbook
+----------------
+
+    - hosts: Management_Worker
+      roles:
+         - role: csm.ncn.enable_chn
+
+License
+-------
+
+MIT
+
+Author Information
+------------------
+
+Copyright 2021 Hewlett Packard Enterprise Development LP

--- a/ansible/roles/csm.ncn.enable_chn/defaults/main.yml
+++ b/ansible/roles/csm.ncn.enable_chn/defaults/main.yml
@@ -1,4 +1,7 @@
-# Copyright 2021 Hewlett Packard Enterprise Development LP
+#
+# MIT License
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -12,14 +15,12 @@
 #
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
 # THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
 # OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-# (MIT License)
-
 # Defaults for the csm.ncn.enable_chn role. See the README.md for information.
 
 chn_interface: hsn0

--- a/ansible/roles/csm.ncn.enable_chn/defaults/main.yml
+++ b/ansible/roles/csm.ncn.enable_chn/defaults/main.yml
@@ -1,0 +1,25 @@
+# Copyright 2021 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# (MIT License)
+
+# Defaults for the csm.ncn.enable_chn role. See the README.md for information.
+
+chn_interface: hsn0

--- a/ansible/roles/csm.ncn.enable_chn/tasks/main.yml
+++ b/ansible/roles/csm.ncn.enable_chn/tasks/main.yml
@@ -1,0 +1,97 @@
+#
+# MIT License
+#
+# (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+---
+- name: "Get BICAN info from SLS"
+  local_action:
+    module: uri
+    url: "http://cray-sls/v1/search/networks?name=BICAN"
+    method: GET
+  register: sls_bican
+
+- name: "Get SystemDefaultRoute from SLS."
+  set_fact:
+    bican_network: "{{ item.ExtraProperties.SystemDefaultRoute }}"
+  loop: "{{ sls_bican.json }}"
+  when: sls_bican.status == 200
+
+- name: "Configure NCN CHN IP addresses"
+  block:
+
+  - name: "Get CHN info from SLS"
+    local_action:
+      module: uri
+      url: "http://cray-sls/v1/search/networks?name=CHN"
+      method: GET
+    register: sls_chn
+
+  - name: "Get CHN Subnets"
+    set_fact:
+      chn_subnets: "{{ item.ExtraProperties.Subnets }}"
+    loop: "{{ sls_chn.json }}"
+
+  - name: "Get CHN data from SLS"
+    set_fact:
+      customer_highspeed_ips: "{{ item.IPReservations }}"
+      customer_highspeed_network: "{{ item.CIDR }}"
+    loop: "{{ chn_subnets }}"
+    when: (sls_bican.status == 200) and (item.Name == "bootstrap_dhcp")
+
+  - name: "Get CHN IP from SLS"
+    set_fact:
+      chn_ip: "{{ item.IPAddress }}"
+    loop: "{{ customer_highspeed_ips }}"
+    when: (sls_bican.status == 200) and (item.Name == ansible_hostname)
+
+  - name: "FAIL if CHN IP is not defined"
+    fail:
+      msg: "CHN IP is not defined for {{ ansible_hostname }}"
+    when: chn_ip is not defined
+
+  - name: "Get CHN Prefix"
+    set_fact:
+      chn_prefix: "{{ customer_highspeed_network | ipaddr('prefix') }}"
+
+  - name: Determine if {{ chn_interface }} device exists
+    shell: "ip -o link list | cut -f 2 -d ':' | tr -d ' ' | grep '{{ chn_interface }}'"
+    register: chn_device
+
+  - name: FAIL if {{ chn_interface }} is not found
+    fail:
+      msg: "Interface {{ chn_interface }} not found."
+    when: (chn_device.stdout_lines | length) < 1
+
+  - name: "Configure CHN IP address on interface {{ chn_interface }}"
+    shell: "ip address add {{ chn_ip }}/{{ chn_prefix }} dev {{ chn_interface }}"
+    failed_when: "result.rc != 0 and 'RTNETLINK answers: File exists' not in result.stderr"
+    register: result
+    when: chn_ip is defined
+
+  - name: "Check that the {{ chn_interface }} interface has the expected IP"
+    shell: "ip addr show {{ chn_interface }} | grep -q {{ chn_ip }}/{{ chn_prefix }}"
+    failed_when: result.rc != 0
+    register: result
+    when: chn_ip is defined
+
+  when:
+    - bican_network == "CHN"

--- a/ansible/roles/csm.ncn.enable_chn/tasks/main.yml
+++ b/ansible/roles/csm.ncn.enable_chn/tasks/main.yml
@@ -75,11 +75,12 @@
   - name: Determine if {{ chn_interface }} device exists
     shell: "ip -o link list | cut -f 2 -d ':' | tr -d ' ' | grep '{{ chn_interface }}'"
     register: chn_device
+    ignore_errors: true
 
   - name: FAIL if {{ chn_interface }} is not found
     fail:
       msg: "Interface {{ chn_interface }} not found."
-    when: (chn_device.stdout_lines | length) < 1
+    when: "(chn_device.stdout_lines | length) < 1 or chn_device.rc != 0"
 
   - name: "Configure CHN IP address on interface {{ chn_interface }}"
     shell: "ip address add {{ chn_ip }}/{{ chn_prefix }} dev {{ chn_interface }}"


### PR DESCRIPTION
## Summary and Scope

Ansible role to determine whether the bifurcated CAN is configured to use CAN or CHN by reading the systemDefaultRoute property from the BICAN SLS network. In the case that CHN is defined configure the CHN IP addresses on the worker HSN interfaces.

HSN interface configuration on the NCNs now requires SHS *and* COS to be installed and configured correctly therefore this role should be configured as a standalone layer to be run after the SHS and COS layers have run.

The reason for this is due to the following actions taken by the SHS and COS layers.

* SHS layer restarts openibd which deletes the existing HSN interface configuration
* COS second layer (ncn-final.yml) restarts the `cray-ifscan` service then waits up to 5 minutes for the HSN interfaces to be configured before installing and configuring DVS and LNet.

Once these two layers have completed a layer containing this role can then be run to configure the CHN IP addresses on the workers. This role is not needed on systems that do not implement the CHN however does nothing if it is enabled and CHN is not.

## Issues and Related PRs

* Resolves [CASMNET-1528](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-1528)
* Documentation changes required in [CASMINST-4135](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4135)

## Testing

### Tested on:

  * `hela` - systemDefaultRoute = CHN
  * `wasp` - systemDefaultRoute = CAN

### Test description:

wasp - Verified that this role does nothing beyond query SLS on a system configured to use CAN.

hela - Verified the following scenarios
  * CHN IP address is applied successfully if HSN interface is configured
     ```
    TASK [csm.ncn.enable_chn : Check that the hsn0 interface has the expected IP] ***
    changed: [x3000c0s7b0n0]
    ```
  * Role fails appropriately if the required HSN interface does not exist.
     ```
    TASK [csm.ncn.enable_chn : FAIL if hsn0 is not found] **************************
    fatal: [x3000c0s7b0n0]: FAILED! => {"changed": false, "msg": "Interface hsn0 not found."}
    ```
  * Role fails appropriately if the SLS CHN network lacks an IP reservation for the node.
    ```
    TASK [csm.ncn.enable_chn : FAIL if CHN IP is not defined] **********************
    fatal: [x3000c0s7b0n0]: FAILED! => {"changed": false, "msg": "CHN IP is not defined for ncn-w004"
    ```

## Risks and Mitigations

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable

