### PR TITLE
CASMCMS-6989: Adds playbook for adding cfs and bos packages to compute

### DIFF
--- a/ansible/compute_nodes.yml
+++ b/ansible/compute_nodes.yml
@@ -1,7 +1,8 @@
+#!/usr/bin/env ansible-playbook
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -21,23 +22,27 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-ncn_csm_sles_packages:
-  - cray-cmstools-crayctldeploy
-  - hms-bss-ct-test
-  - hms-capmc-ct-test
-  - hms-ct-test-base
-  - hms-fas-ct-test
-  - hms-hmcollector-ct-test
-  - hms-hbtd-ct-test
-  - hms-hmnfd-ct-test
-  - hms-meds-ct-test
-  - hms-reds-ct-test
-  - hms-rts-ct-test
-  - hms-scsd-ct-test
-  - hms-sls-ct-test
-  - hms-smd-ct-test
-  - loftsman
+# Compute Nodes Play
+- hosts: Compute
+  gather_facts: yes
+  any_errors_fatal: true
+  remote_user: root
+  vars_files:
+    - vars/csm_repos.yml
+    - vars/csm_packages.yml
 
-compute_csm_sles_packages:
-  - bos-reporter
-  - cfs-state-reporter
+  roles:
+    # Install CSM repositories and packages
+    - role: csm.packages
+      vars:
+        packages: "{{ compute_csm_sles_packages }}"
+      when: ansible_distribution == "SLES"
+
+  tasks:
+    - name: Add reporters to presets file
+      blockinfile:
+        path: "/usr/lib/systemd/system-preset/89-cray-default.preset"
+        block: |
+          # More Cray services
+          enable bos-reporter.service
+          enable cfs-state-reporter.service

--- a/ansible/ncn-master_nodes.yml
+++ b/ansible/ncn-master_nodes.yml
@@ -39,6 +39,9 @@
 
     # Install CSM repositories and packages
     - role: csm.packages
+      vars:
+        packages: "{{ ncn_csm_sles_packages }}"
+      when: ansible_os_family == "SLE_HPC"
 
     # Set the root password from the value stored in cray-vault
     - role: csm.password

--- a/ansible/ncn-storage_nodes.yml
+++ b/ansible/ncn-storage_nodes.yml
@@ -39,6 +39,9 @@
 
     # Install CSM repositories and packages
     - role: csm.packages
+      vars:
+        packages: "{{ ncn_csm_sles_packages }}"
+      when: ansible_os_family == "SLE_HPC"
 
     # Set the root password from the value stored in cray-vault
     - role: csm.password

--- a/ansible/ncn-worker_nodes.yml
+++ b/ansible/ncn-worker_nodes.yml
@@ -39,6 +39,9 @@
 
     # Install CSM repositories and packages
     - role: csm.packages
+      vars:
+        packages: "{{ ncn_csm_sles_packages }}"
+      when: ansible_os_family == "SLE_HPC"
 
     # Set the root password from the value stored in cray-vault
     - role: csm.password

--- a/ansible/packages.yml
+++ b/ansible/packages.yml
@@ -35,3 +35,6 @@
 
     # Install CSM repositories and packages
     - role: csm.packages
+      vars:
+        packages: "{{ ncn_csm_sles_packages }}"
+      when: ansible_os_family == "SLE_HPC"

--- a/ansible/roles/csm.packages/tasks/main.yml
+++ b/ansible/roles/csm.packages/tasks/main.yml
@@ -29,7 +29,6 @@
     repo: "{{ item.repo }}"
     state: present
     disable_gpg_check: "{{ item.disable_gpg_check | default('no') }}"
-  when: ansible_os_family == "SLE_HPC"
   loop: "{{ csm_sles_repositories }}"
 
 # CSM repos are generated during the release distribution creation and
@@ -40,12 +39,9 @@
   args:
     warn: no  # Ansible's Zypper module does not provide this feature
   loop: "{{ csm_sles_repositories }}"
-  when: ansible_os_family == "SLE_HPC"
 
 - name: Install RPMs (SLES-based)
   zypper:
-    name: "{{ csm_sles_packages }}"
+    name: "{{ packages }}"
     state: latest
     update_cache: yes
-  when: ansible_os_family == "SLE_HPC"
-


### PR DESCRIPTION
## Summary and Scope

This adds a new playbook that can be run in order to add the cfs-state-reporter and bos-reporter packages so that they can be removed the image recipe.  There will be a corresponding change in the docs to add this layer in image customization.

The new playbook will not work completely until the bos-v2 branch is merged and deployments include the bos-reporter in nexus.

## Issues and Related PRs

* Resolves CASMCMS-6989

## Testing

### Tested on:

  * Hela

### Test description:

Tested image creation with the new layer.  The test did fail on bos-reporter because it is not yet available.


## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

