### PR TITLE
CASMCMS-6989: Expand csm packages to compute and application nodes

### DIFF
--- a/ansible/csm_packages.yml
+++ b/ansible/csm_packages.yml
@@ -23,7 +23,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 # Compute Nodes Play
-- hosts: Compute
+- hosts: Compute,Application
   gather_facts: yes
   any_errors_fatal: true
   remote_user: root
@@ -35,7 +35,7 @@
     # Install CSM repositories and packages
     - role: csm.packages
       vars:
-        packages: "{{ compute_csm_sles_packages }}"
+        packages: "{{ general_csm_sles_packages }}"
       when: ansible_distribution == "SLES"
 
   tasks:

--- a/ansible/vars/csm_packages.yml
+++ b/ansible/vars/csm_packages.yml
@@ -38,6 +38,6 @@ ncn_csm_sles_packages:
   - hms-smd-ct-test
   - loftsman
 
-compute_csm_sles_packages:
+general_csm_sles_packages:
   - bos-reporter
   - cfs-state-reporter


### PR DESCRIPTION
## Summary and Scope

Updates the play that is installing the cfs and bos reporters to include application nodes.

## Issues and Related PRs

* Resolves CASMCMS-6989

## Testing

### Tested on:

  * Groot

### Test description:

Ran the playbook on Compute and Application nodes

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

