### PR TITLE
CASMCMS-8104: Use updated versions of cf-gitea-import and csm-ssh-keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Modified build to create valid unstable charts
 - Added Mitch Harding as a maintainer
+- Update minor version number used for csm-ssh-keys and cf-gitea-import
 
 ### Removed
 

--- a/update_external_versions.conf
+++ b/update_external_versions.conf
@@ -80,7 +80,7 @@
 
 image: cf-gitea-import
     major: 1
-    minor: 5
+    minor: 6
 
 # We actually want the latest stable RPM version of csm-ssh-keys-roles, but that function is not yet
 # available in update_external_versions. Fortunately, however, we use the same version for
@@ -90,5 +90,5 @@ image: cf-gitea-import
 # latest stable RPM version.
 image: csm-ssh-keys
     major: 1
-    minor: 4
+    minor: 5
 


### PR DESCRIPTION
## Summary and Scope

I realized that csm-config was still using the old versions of cf-gitea-import and csm-ssh-keys, even though there have been changes made to those both relatively recently. This PR updates it to using the newer versions.

## Testing

Just build testing so far.

## Risks and Mitigations

Probably riskier to not use the new versions, since we're making changes to them for a reason.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
