### PR TITLE
CASMINST-5090: Remove HSM CT test RPMs from CSM packages list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Removed HMS test RPMs from CSM packages list, as they are no longer used as of CSM 1.3
+
 ## [1.10.1] - 2022-07-21
 
 ### Added

--- a/ansible/vars/csm_packages.yml
+++ b/ansible/vars/csm_packages.yml
@@ -23,19 +23,6 @@
 #
 ncn_csm_sles_packages:
   - cray-cmstools-crayctldeploy
-  - hms-bss-ct-test
-  - hms-capmc-ct-test
-  - hms-ct-test-base
-  - hms-fas-ct-test
-  - hms-hmcollector-ct-test
-  - hms-hbtd-ct-test
-  - hms-hmnfd-ct-test
-  - hms-meds-ct-test
-  - hms-reds-ct-test
-  - hms-rts-ct-test
-  - hms-scsd-ct-test
-  - hms-sls-ct-test
-  - hms-smd-ct-test
   - loftsman
 
 general_csm_sles_packages:


### PR DESCRIPTION
## Summary and Scope

The HMS CT test RPMs are no longer used in CSM 1.3. This PR stops them from trying to be installed during NCN personalization. Without this change, NCN personalization fails, since the RPMs are not there.

## Testing

This problem was reported on tyr. I hot patched this change into the csm config repo on tyr and verified that it fixed the problem.

## Risks and Mitigations

Low risk -- just removing RPMs from the list. Nothing new is added.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
