### PR TITLE
MTL-1864

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- added csm.ncn.ca_cert role to install platform cert
+
 ### Removed
 
 - Removed HMS test RPMs from CSM packages list, as they are no longer used as of CSM 1.3

--- a/ansible/ncn-master_nodes.yml
+++ b/ansible/ncn-master_nodes.yml
@@ -37,6 +37,9 @@
     - role: trust-csm-ssh-keys
     - role: passwordless-ssh
 
+    # Install the platform certificate
+    - role: csm.ncn.ca_cert
+
     # Install CSM repositories and packages
     - role: csm.packages
       vars:

--- a/ansible/ncn-storage_nodes.yml
+++ b/ansible/ncn-storage_nodes.yml
@@ -37,6 +37,9 @@
     - role: trust-csm-ssh-keys
     - role: passwordless-ssh
 
+    # Install the platform certificate
+    - role: csm.ncn.ca_cert
+
     # Install CSM repositories and packages
     - role: csm.packages
       vars:

--- a/ansible/ncn-worker_nodes.yml
+++ b/ansible/ncn-worker_nodes.yml
@@ -37,6 +37,9 @@
     - role: trust-csm-ssh-keys
     - role: passwordless-ssh
 
+    # Install the platform certificate
+    - role: csm.ncn.ca_cert
+
     # Install CSM repositories and packages
     - role: csm.packages
       vars:
@@ -53,5 +56,3 @@
       vars:
         ssh_keys_username: 'root'
 
-    # Install the platform certificate 
-    - role: csm.ncn.ca_cert

--- a/ansible/roles/csm.ncn.ca_cert/README.md
+++ b/ansible/roles/csm.ncn.ca_cert/README.md
@@ -1,0 +1,38 @@
+cf-cme-motd
+=========
+
+An Ansible role for installing a CA certificate onto the system.
+
+Requirements
+------------
+
+None
+
+Role Variables
+--------------
+
+None.
+
+Dependencies
+------------
+
+cms-meta-tools
+
+Example Playbook
+----------------
+
+```yaml
+- hosts: Management_Worker
+  roles:
+     - role: csm.ncn.ca_cert
+```
+
+License
+-------
+
+MIT
+
+Author Information
+------------------
+
+Copyright 2022 Hewlett Packard Enterprise Development LP

--- a/ansible/roles/csm.ncn.ca_cert/defaults/main.yml
+++ b/ansible/roles/csm.ncn.ca_cert/defaults/main.yml
@@ -1,8 +1,7 @@
-#!/usr/bin/env ansible-playbook
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019,2021-2022 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -22,36 +21,8 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-# NCN Worker Nodes Play
-- hosts: Management_Worker
-  gather_facts: yes
-  any_errors_fatal: true
-  remote_user: root
-  vars_files:
-    - vars/csm_repos.yml
-    - vars/csm_packages.yml
+---
+# defaults file for ca-cert
 
-  roles:
-    # Allow trust of CSM generated keys for elective passwordless SSH;
-    # Enables both passwordless ssh from, and to, all nodes.
-    - role: trust-csm-ssh-keys
-    - role: passwordless-ssh
-
-    # Install CSM repositories and packages
-    - role: csm.packages
-      vars:
-        packages: "{{ ncn_csm_sles_packages }}"
-      when: ansible_os_family == "SLE_HPC"
-
-    # Set the root password from the value stored in cray-vault
-    - role: csm.password
-      vars:
-        password_username: 'root'
-
-    # Distribute SSH keys for the root user
-    - role: csm.ssh_keys
-      vars:
-        ssh_keys_username: 'root'
-
-    # Install the platform certificate 
-    - role: csm.ncn.ca_cert
+ca_cert_file: /etc/cray/ca/certificate_authority.crt 
+ca_cert_dest_dir: /usr/share/pki/trust/anchors/

--- a/ansible/roles/csm.ncn.ca_cert/tasks/main.yml
+++ b/ansible/roles/csm.ncn.ca_cert/tasks/main.yml
@@ -1,0 +1,60 @@
+#
+# MIT License
+#
+# (C) Copyright 2019,2021-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+---
+# Install a Cray CA certificate onto a SLES system.
+
+- name: Copy CA certificate to the canonical location
+  copy:
+    src: "{{ ca_cert_file }}"
+    dest: "{{ ca_cert_dest_dir }}"
+    remote_src: yes
+
+# NOTE: Only run this in SLES 15 SP2, since the version in SLES 15 SP3
+# doesn't work in a chrooted environment.
+- name: Update the certificate
+  command: update-ca-certificates
+  when: >
+    ansible_distribution == "SLES" and
+    ansible_distribution_version == "15.2"
+
+# In SLES 15 SP3/SP4, run the certificate update scripts directly
+- name: Find certificate update scripts
+  find:
+    paths:
+    - /etc/ca-certificates/update.d
+    - /usr/lib/ca-certificates/update.d
+    patterns:
+    - '*.run'
+  register: ca_scripts
+  when: >
+    ansible_distribution == "SLES" and
+    ansible_distribution_version != "15.2"
+
+
+- name: Run certificate update scripts
+  command: "{{ item.path }}"
+  loop: "{{ ca_scripts.files }}"
+  when: >
+    ansible_distribution == "SLES" and
+    ansible_distribution_version != "15.2"

--- a/ansible/roles/csm.ncn.ca_cert/tasks/main.yml
+++ b/ansible/roles/csm.ncn.ca_cert/tasks/main.yml
@@ -35,7 +35,8 @@
 - name: Update the certificate
   command: update-ca-certificates
   when: >
-    ansible_distribution == "SLES" and
+    (ansible_distribution == "SLES" or 
+    ansible_distribution == "SLE_HPC") and
     ansible_distribution_version == "15.2"
 
 # In SLES 15 SP3/SP4, run the certificate update scripts directly
@@ -48,7 +49,8 @@
     - '*.run'
   register: ca_scripts
   when: >
-    ansible_distribution == "SLES" and
+    (ansible_distribution == "SLES" or 
+    ansible_distribution == "SLE_HPC") and
     ansible_distribution_version != "15.2"
 
 
@@ -56,5 +58,6 @@
   command: "{{ item.path }}"
   loop: "{{ ca_scripts.files }}"
   when: >
-    ansible_distribution == "SLES" and
+    (ansible_distribution == "SLES" or 
+    ansible_distribution == "SLE_HPC") and
     ansible_distribution_version != "15.2"

--- a/ansible/roles/csm.ncn.ca_cert/tasks/main.yml
+++ b/ansible/roles/csm.ncn.ca_cert/tasks/main.yml
@@ -35,7 +35,7 @@
 - name: Update the certificate
   command: update-ca-certificates
   when: >
-    (ansible_distribution == "SLES" or 
+    (ansible_distribution == "SLES" or
     ansible_distribution == "SLE_HPC") and
     ansible_distribution_version == "15.2"
 
@@ -49,7 +49,7 @@
     - '*.run'
   register: ca_scripts
   when: >
-    (ansible_distribution == "SLES" or 
+    (ansible_distribution == "SLES" or
     ansible_distribution == "SLE_HPC") and
     ansible_distribution_version != "15.2"
 
@@ -58,6 +58,6 @@
   command: "{{ item.path }}"
   loop: "{{ ca_scripts.files }}"
   when: >
-    (ansible_distribution == "SLES" or 
+    (ansible_distribution == "SLES" or
     ansible_distribution == "SLE_HPC") and
     ansible_distribution_version != "15.2"


### PR DESCRIPTION
## Summary and Scope

Adds the **ca-cert** role from https://github.com/Cray-HPE/cf-cme-ca-cert for the purpose of installing the platform certificate on ncn worker nodes and to make the role available for image customization.

backwards compatible

## Issues and Related PRs
https://jira-pro.its.hpecorp.net:8443/browse/MTL-1864

Documentation is WIP

## Testing

### Tested on:

  * Hermod

### Test description:

Tested on hermod with James Clough

## Risks and Mitigations

No known issues.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

