### PR TITLE
CASMINST-5187

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- added conditional to csm.ncn.ca_cert checks for the existence of certificate_authority.crt before proceeding
+
+### Added
+
 - added csm.ncn.ca_cert role to install platform cert
 
 ### Removed

--- a/ansible/roles/csm.ncn.ca_cert/tasks/main.yml
+++ b/ansible/roles/csm.ncn.ca_cert/tasks/main.yml
@@ -24,11 +24,17 @@
 ---
 # Install a Cray CA certificate onto a SLES system.
 
+- name: Check for the existence of certificate_authority.crt
+  stat:
+    path: "{{ ca_cert_file }}"
+  register: cert_file
+
 - name: Copy CA certificate to the canonical location
   copy:
     src: "{{ ca_cert_file }}"
     dest: "{{ ca_cert_dest_dir }}"
     remote_src: yes
+  when: cert_file.stat.exists
 
 # NOTE: Only run this in SLES 15 SP2, since the version in SLES 15 SP3
 # doesn't work in a chrooted environment.
@@ -37,7 +43,9 @@
   when: >
     (ansible_distribution == "SLES" or
     ansible_distribution == "SLE_HPC") and
-    ansible_distribution_version == "15.2"
+    ansible_distribution_version == "15.2" and
+    cert_file.stat.exists
+
 
 # In SLES 15 SP3/SP4, run the certificate update scripts directly
 - name: Find certificate update scripts
@@ -51,7 +59,8 @@
   when: >
     (ansible_distribution == "SLES" or
     ansible_distribution == "SLE_HPC") and
-    ansible_distribution_version != "15.2"
+    ansible_distribution_version != "15.2" and
+    cert_file.stat.exists
 
 
 - name: Run certificate update scripts
@@ -60,4 +69,5 @@
   when: >
     (ansible_distribution == "SLES" or
     ansible_distribution == "SLE_HPC") and
-    ansible_distribution_version != "15.2"
+    ansible_distribution_version != "15.2" and
+    cert_file.stat.exists


### PR DESCRIPTION
## Summary and Scope

added conditional to csm.ncn.ca_cert to check for the existence of **certificate_authority.crt** before proceeding.
ncn-personalization halted because the cert didn't exist on disk. Fixes ncn-personalization.

## Issues and Related PRs

* Resolves https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5187

## Testing


### Tested on:

  * surtur

### Test description:

ncn-personalization executed successfully on surtur with this change

## Risks and Mitigations

Not aware of any risks.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

