### PR TITLE
CASMCMS-8099 - apply security patches to base image.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,17 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- make Dockerfile update base image with security patches
 
 ### Added
-
 - added conditional to csm.ncn.ca_cert checks for the existence of certificate_authority.crt before proceeding
-
-### Added
-
 - added csm.ncn.ca_cert role to install platform cert
 
 ### Removed
-
 - Removed HMS test RPMs from CSM packages list, as they are no longer used as of CSM 1.3
 
 ## [1.10.1] - 2022-07-21

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,6 +72,15 @@ COPY zypper-refresh-patch-clean.sh /
 RUN /zypper-refresh-patch-clean.sh && rm /zypper-refresh-patch-clean.sh
 
 FROM artifactory.algol60.net/csm-docker/stable/cf-gitea-import:@CF_GITEA_IMPORT_VERSION@ as cf-gitea-import-base
+
+# apply security patches to the cf-gitea-import base image
+#  NOTE: do this here in case base image isn't being updated regularly
+USER root:root
+RUN apk update && \
+    apk add --upgrade apk-tools &&  \
+    apk -U upgrade && \
+    rm -rf /var/cache/apk/*
+
 USER nobody:nobody
 WORKDIR /
 ENV CF_IMPORT_PRODUCT_NAME=csm


### PR DESCRIPTION
## Summary and Scope

The base image for the final layer may or may not have security patches applied, so each time this is built, apply any security patches directly to it here.  This does not rely on the base image being updated to get all patches at the time of the build.

## Issues and Related PRs

* Resolves [CASMCMS-8099](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8099)

## Testing
### Tested on:
  * Build system

### Test description:

The image built with the Jenkins pipeline failed the CVE scan before the changes, and passes after the changes.  There are no code changes, just a base image update so no need to test on-system.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? N
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Very low risk, just applies CVE updates to the base image in this dockerfile instead of relying on the base image getting rebuilt.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

