### PR TITLE
CASMINST-5269 - enable the embedded repo to be added to the ncns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
-## [1.13.0] - 2022-08-23
 ### Changed
 - enabling the embedded repos on the ncns
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.13.0] - 2022-08-23
+### Changed
+- enabling the embedded repos on the ncns
+
 ## [1.12.0] - 2022-08-16
 ### Changed
 - make Dockerfile update base image with security patches

--- a/ansible/vars/csm_repos.yml
+++ b/ansible/vars/csm_repos.yml
@@ -28,3 +28,7 @@ csm_sles_repositories:
 - name: csm-sle-15sp3
   description: "CSM SLE 15 SP3 Packages (added by Ansible)"
   repo: https://packages.local/repository/csm-sle-15sp3
+- name: csm-embedded
+  description: "CSM SLE Embedded Packages (added by Ansible)"
+  repo: https://packages.local/repository/csm-embedded
+


### PR DESCRIPTION
## Summary and Scope

Enabling the embedded repo so it is added to zypper on the ncns

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASMINST-5269
* Merge with/before/after [CSM-config Branch]https://github.com/Cray-HPE/csm/pull/1212 (csm CASMINST-5269 branch)

## Testing
TBD
_List the environments in which these changes were tested._

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

