### PR TITLE
MTL-1921: add csm.ncn-initrd role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- added a role and playbook for creating an NCN initrd
+
 ## [1.12.0] - 2022-08-16
 ### Changed
 - make Dockerfile update base image with security patches

--- a/ansible/ncn-initrd.yml
+++ b/ansible/ncn-initrd.yml
@@ -1,0 +1,32 @@
+#!/usr/bin/env ansible-playbook
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# NCN Worker Nodes Play
+- hosts: Management_Worker
+  any_errors_fatal: true
+  remote_user: root
+
+  roles:
+    # Creates an NCN initrd during pre-boot image customization
+    - role: csm.ncn-initrd

--- a/ansible/roles/csm.ncn-initrd/README.md
+++ b/ansible/roles/csm.ncn-initrd/README.md
@@ -1,0 +1,38 @@
+ncn-initrd
+=========
+
+An Ansible role for creating an NCN initrd
+
+Requirements
+------------
+
+None
+
+Role Variables
+--------------
+
+None.
+
+Dependencies
+------------
+
+cms-meta-tools
+
+Example Playbook
+----------------
+
+```yaml
+- hosts: Management_Worker
+  roles:
+     - role: csm.ncn-initrd
+```
+
+License
+-------
+
+MIT
+
+Author Information
+------------------
+
+Copyright 2022 Hewlett Packard Enterprise Development LP

--- a/ansible/roles/csm.ncn-initrd/tasks/main.yml
+++ b/ansible/roles/csm.ncn-initrd/tasks/main.yml
@@ -1,0 +1,29 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+---
+# Create an initrd for the NCN image being modified by CFS
+
+- name: Create NCN initrd
+  command: /srv/cray/scripts/common/create-ims-initrd.sh
+  when: cray_cfs_image|default(false)|bool


### PR DESCRIPTION
## Summary and Scope

Provide a role and playbook for creating an NCN initrd.  This is
a helper role for pre-boot NCN image modification.

## Issues and Related PRs

* Resolves [MTL-1921](https://jira-pro.its.hpecorp.net:8443/browse/MTL-1921)

## Testing

### Tested on:

  * `surtur`

### Test description:

See PR comments.

## Risks and Mitigations

No risks.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

