### PR TITLE
CASMCMS-8209: Add csm-sle15sp4 repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Defined csm-sle-15sp4 zypper repository
 
 ## [1.13.0] - 2022-09-02
 ### Added

--- a/ansible/vars/csm_repos.yml
+++ b/ansible/vars/csm_repos.yml
@@ -28,3 +28,6 @@ csm_sles_repositories:
 - name: csm-sle-15sp3
   description: "CSM SLE 15 SP3 Packages (added by Ansible)"
   repo: https://packages.local/repository/csm-sle-15sp3
+- name: csm-sle-15sp4
+  description: "CSM SLE 15 SP4 Packages (added by Ansible)"
+  repo: https://packages.local/repository/csm-sle-15sp4


### PR DESCRIPTION
## Summary and Scope

[CASMTRIAGE-4094](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4094) was opened because no source for the cfs-state-reporter RPM was found on a system. It turns out that the SLES SP4 RPMs in the tarball were not getting loaded into Nexus. [CASMINST-5314](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5314) made the changes to get them loaded into Nexus. This PR is modifying csm-config so that it will configure the new repository during NCN personalization.

## Issues and Related PRs

- Resolves [CASMCMS-8209](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8209).
- Combined with [CASMINST-5314](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5314), resolves [CASMTRIAGE-4094](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4094).

## Testing

I have not been able to test the actual updated artifact yet because I don't have a system available that is in the right state, but the change is to just copy the exact same stanza for the other SLES SP* repos and just update the version number. On surtur, I did copy the updated repos YAML file and verified that it does correctly create the repository on the NCNs.

## Risks and Mitigations

Very low risk.

## Pull Request Checklist

- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
