### PR TITLE
CASMCMS-5516: Add cfs-debugger to ncn packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - CONTRIBUTING.md file
 - CASMCMS-8241: Added unified csm management node playbook ncn_nodes.yml
+- CASMCMS-5516: Added cfs-debugger to ncn packages
 ### Changed
 - CASMCMS-8242: Converted ncn-initrd.yml over to new cfs_image host protocol invocation
 - CASMCMS-8241: Broke ncn-(master,storage,worker)_nodes.yml into node and node+image specific playbooks

--- a/ansible/vars/csm_packages.yml
+++ b/ansible/vars/csm_packages.yml
@@ -24,6 +24,7 @@
 ncn_csm_sles_packages:
   - cray-cmstools-crayctldeploy
   - loftsman
+  - cfs-debugger
 
 general_csm_sles_packages:
   - bos-reporter


### PR DESCRIPTION
## Summary and Scope

Adds the cfs-debugger to the ncn package list

## Issues and Related PRs

* Resolves CASMCMS-5516

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

