### PR TITLE
CASMTRIAGE-5003: Only install Compute packages during image customization (csm-1.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.14.2] - 2023-03-01
+### Changed
+- CASMTRIAGE-5003: Package installation for Compute nodes will only run during image customization
+
 ## [1.14.1] - 2023-01-06
 ### Added
 - Add Artifactory authentication to Jenkinsfile

--- a/ansible/csm_packages.yml
+++ b/ansible/csm_packages.yml
@@ -36,7 +36,9 @@
     - role: csm.packages
       vars:
         packages: "{{ general_csm_sles_packages }}"
-      when: ansible_distribution == "SLES"
+      when:
+        - ansible_distribution == "SLES"
+        - cray_cfs_image|default(false)|bool
 
   tasks:
     - name: Add reporters to presets file


### PR DESCRIPTION
## Summary and Scope

Updates Compute and Application node playbooks so that package install will only run during image customization and not at boot time.

This uses different syntax from https://github.com/Cray-HPE/csm-config/pull/93 because older releases of CFS did not support the "cfs_image" host group.

## Issues and Related PRs

* Resolves CASMTRIAGE-5003

## Testing

### Tested on:

  * Surtur

### Test description:

Ran the update against a node to confirm the role did not run

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

