### PR TITLE
CASMINST-6041: allow ncn-initrd.yml to be used with all image types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.15.5] - 2023-03-03
+### Changed
+- CASMINST-6041: allow ncn-initrd.yml to be used with all image types
+
 ## [1.15.4] - 2023-03-01
 ### Changed
 - CASMTRIAGE-5003: Package installation for Compute nodes will only run during image customization

--- a/ansible/ncn-initrd.yml
+++ b/ansible/ncn-initrd.yml
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -23,7 +23,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 # NCN Worker Nodes Play
-- hosts: Management_Worker:&cfs_image
+- hosts: "Management_Master:Management_Worker:Management_Storage:&cfs_image"
   any_errors_fatal: true
   remote_user: root
 


### PR DESCRIPTION
## Summary and Scope

IUF/sat now modifies storage and master images in addition to worker images. This commit adds the storage and master image classes to the 'hosts' in ncn-initrd.yml to allow an initrd to be created for those image types.

## Issues and Related PRs

* Resolves [CASMINST-6041](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-6041)

## Testing

### Tested on:

  * not yet tested

### Test description:

## Risks and Mitigations

N/A

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

