### PR TITLE
CASMCMS-8441: Build Docker image using mirrors of csm-rpms and csm-docker repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- CASMCMS-8441: Use csm-rpms/csm-docker mirrors when building image; remove old commented lines from Dockerfile
+
 ## [1.15.4] - 2023-03-01
 ### Changed
 - CASMTRIAGE-5003: Package installation for Compute nodes will only run during image customization
@@ -78,7 +84,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ansible playbook for applying csm packages to Compute and Application nodes
 
-[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.14.0...HEAD
+[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.15.4...HEAD
+
+[1.15.4]: https://github.com/Cray-HPE/csm-config/compare/1.15.3...1.15.4
+
+[1.15.3]: https://github.com/Cray-HPE/csm-config/compare/1.15.2...1.15.3
+
+[1.15.2]: https://github.com/Cray-HPE/csm-config/compare/1.15.1...1.15.2
+
+[1.15.1]: https://github.com/Cray-HPE/csm-config/compare/1.15.0...1.15.1
+
+[1.15.0]: https://github.com/Cray-HPE/csm-config/compare/1.14.0...1.15.0
 
 [1.14.0]: https://github.com/Cray-HPE/csm-config/compare/1.13.0...1.14.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -36,33 +36,12 @@ RUN \
   zypper --non-interactive rr --all &&\
   zypper --non-interactive ar ${SLES_MIRROR}/Products/SLE-Module-Basesystem/15-SP4/${ARCH}/product/ sles15sp4-Module-Basesystem-product &&\
   zypper --non-interactive ar ${SLES_MIRROR}/Updates/SLE-Module-Basesystem/15-SP4/${ARCH}/update/ sles15sp4-Module-Basesystem-update &&\
-#  zypper --non-interactive ar ${SLES_MIRROR}/Products/SLE-Module-Development-Tools/15-SP4/${ARCH}/product/ sles15sp4-Module-Development-Tools-product &&\
-#  zypper --non-interactive ar ${SLES_MIRROR}/Updates/SLE-Module-Development-Tools/15-SP4/${ARCH}/update/ sles15sp4-Module-Development-Tools-update &&\
-#  zypper --non-interactive ar ${SLES_MIRROR}/Products/SLE-Module-Containers/15-SP4/${ARCH}/product/ sles15sp4-Module-Containers-product &&\
-#  zypper --non-interactive ar ${SLES_MIRROR}/Updates/SLE-Module-Containers/15-SP4/${ARCH}/update/ sles15sp4-Module-Containers-update &&\
-#  zypper --non-interactive ar ${SLES_MIRROR}/Products/SLE-Module-Desktop-Applications/15-SP4/${ARCH}/product/ sles15sp4-Module-Desktop-Applications-product &&\
-#  zypper --non-interactive ar ${SLES_MIRROR}/Updates/SLE-Module-Desktop-Applications/15-SP4/${ARCH}/update/ sles15sp4-Module-Desktop-Applications-update &&\
-#  zypper --non-interactive ar ${SLES_MIRROR}/Products/SLE-Module-HPC/15-SP4/${ARCH}/product/ sles15sp4-Module-HPC-product &&\
-#  zypper --non-interactive ar ${SLES_MIRROR}/Updates/SLE-Module-HPC/15-SP4/${ARCH}/update/ sles15sp4-Module-HPC-update &&\
-#  zypper --non-interactive ar ${SLES_MIRROR}/Products/SLE-Module-Legacy/15-SP4/${ARCH}/product/ sles15sp4-Module-Legacy-product &&\
-#  zypper --non-interactive ar ${SLES_MIRROR}/Updates/SLE-Module-Legacy/15-SP4/${ARCH}/update/ sles15sp4-Module-Legacy-update &&\
-#  zypper --non-interactive ar ${SLES_MIRROR}/Products/SLE-Module-Public-Cloud/15-SP4/${ARCH}/product/ sles15sp4-Module-Public-Cloud-product &&\
-#  zypper --non-interactive ar ${SLES_MIRROR}/Updates/SLE-Module-Public-Cloud/15-SP4/${ARCH}/update/ sles15sp4-Module-Public-Cloud-update &&\
-#  zypper --non-interactive ar ${SLES_MIRROR}/Products/SLE-Module-Python2/15-SP4/${ARCH}/product/ sles15sp4-Module-Python2-product &&\
-#  zypper --non-interactive ar ${SLES_MIRROR}/Updates/SLE-Module-Python2/15-SP4/${ARCH}/update/ sles15sp4-Module-Python2-update &&\
-#  zypper --non-interactive ar ${SLES_MIRROR}/Products/SLE-Module-Server-Applications/15-SP4/${ARCH}/product/ sles15sp4-Module-Server-Applications-product &&\
-#  zypper --non-interactive ar ${SLES_MIRROR}/Updates/SLE-Module-Server-Applications/15-SP4/${ARCH}/update/ sles15sp4-Module-Server-Applications-update &&\
-#  zypper --non-interactive ar ${SLES_MIRROR}/Products/SLE-Module-Web-Scripting/15-SP4/${ARCH}/product/ sles15sp4-Module-Web-Scripting-product &&\
-#  zypper --non-interactive ar ${SLES_MIRROR}/Updates/SLE-Module-Web-Scripting/15-SP4/${ARCH}/update/ sles15sp4-Module-Web-Scripting-update &&\
-#  zypper --non-interactive ar ${SLES_MIRROR}/Products/SLE-Product-SLES/15-SP4/${ARCH}/product/ sles15sp4-Product-SLES-product &&\
-#  zypper --non-interactive ar ${SLES_MIRROR}/Updates/SLE-Product-SLES/15-SP4/${ARCH}/update/ sles15sp4-Product-SLES-update &&\
-#  zypper --non-interactive ar ${SLES_MIRROR}/Updates/SLE-INSTALLER/15-SP4/${ARCH}/update/ sles15sp4-SLE-INSTALLER-update &&\
   zypper --non-interactive clean &&\
   zypper --non-interactive --gpg-auto-import-keys refresh
 
 # Install csm-ssh-keys-roles RPM, and lock the version, just to be certain it is not
 # upgraded inadvertently somehow later
-RUN zypper ar --no-gpgcheck https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp4/ csm && \
+RUN zypper ar --no-gpgcheck https://arti.hpc.amslabs.hpecorp.net/artifactory/csm-rpms-remote/hpe/stable/sle-15sp4/ csm && \
     zypper refresh && \
     zypper in -f --no-confirm csm-ssh-keys-roles-${CSM_SSH_KEYS_VERSION} && \
     zypper al csm-ssh-keys-roles
@@ -71,7 +50,7 @@ RUN zypper ar --no-gpgcheck https://artifactory.algol60.net/artifactory/csm-rpms
 COPY zypper-refresh-patch-clean.sh /
 RUN /zypper-refresh-patch-clean.sh && rm /zypper-refresh-patch-clean.sh
 
-FROM artifactory.algol60.net/csm-docker/stable/cf-gitea-import:@CF_GITEA_IMPORT_VERSION@ as cf-gitea-import-base
+FROM arti.hpc.amslabs.hpecorp.net/csm-docker-remote/stable/cf-gitea-import:@CF_GITEA_IMPORT_VERSION@ as cf-gitea-import-base
 
 # apply security patches to the cf-gitea-import base image
 #  NOTE: do this here in case base image isn't being updated regularly


### PR DESCRIPTION
## Summary and Scope

This change corrects build failures being seen due to [CASMINST-4829](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4829).

No functional changes -- just changes to where the build looks for a couple of respositories.

## Issues and Related PRs

- Resolves: [CASMCMS-8441](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8441)
- Caused by: [CASMINST-4829](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4829)
- Blocking being able to build the fix for: [CASMINST-6051](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-6051)

## Testing

No testing beyond making sure the builds now work.

## Risks and Mitigations

Low risk -- without this change, building doesn't happen.

## Pull Request Checklist

- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
