### PR TITLE
CASMTRIAGE-5050: Enable targeted fact-gathering in csm_packages.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- CASMTRIAGE-5050: Enable targeted fact-gathering in [`csm_packages.yml`](ansible/csm_packages.yml) to ensure that the `ansible_distribution` variable is set
+
 ## [1.15.8] - 2023-03-08
 
 ### Changed

--- a/ansible/csm_packages.yml
+++ b/ansible/csm_packages.yml
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -24,7 +24,12 @@
 #
 # Compute Nodes Play
 - hosts: Compute:Application:&cfs_image
-  gather_facts: no
+  gather_facts: yes
+  # Gather the minimum that gets the ansible_distribution variable set
+  gather_subset:
+    - '!all'
+    - '!min'
+    - distribution
   any_errors_fatal: true
   remote_user: root
   vars_files:


### PR DESCRIPTION
## Summary and Scope

[CASMTRIAGE-5050](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5050) was opened because the csm_packages play was failing. The resulting investigation revealed that the play needed the `ansible_distribution` variable to be set, but the play had `gather_facts` set to `no`.

This PR enables fact gathering for that play, but enables the minimum necessary in order to get that variable set (since gathering facts is a performance hit).

## Issues and Related PRs

- Resolves [CASMTRIAGE-5050](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-5050)
- Injected by [CASMCMS-8240](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8240) (c03295cca5823269973e78f1b1c20c4065fdbc32)

## Testing

I tested on baldar and verified that the play works with these changes made (but does not work with fact-gathering disabled).

## Risks and Mitigations

Low risk -- broken without this.

## Pull Request Checklist

- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
