### PR TITLE
CASMCMS-8483: Deprecate unused cfs trust ansible role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.15.11] - 2023-03-22
 
 ### Changed
-
+- CASMCMS-8483: Deprecate unused ansible role from ncn playbooks
 - CASM-3071: Add ansible code for the csm-compute image
 
 ## [1.15.10] - 2023-03-17

--- a/ansible/ncn-master_nodes.yml
+++ b/ansible/ncn-master_nodes.yml
@@ -41,7 +41,6 @@
     - vars/csm_repos.yml
     - vars/csm_packages.yml
   roles:
-    - role: trust-csm-ssh-keys
     - role: csm.ca_cert
     - role: csm.packages
       vars:

--- a/ansible/ncn-storage_nodes.yml
+++ b/ansible/ncn-storage_nodes.yml
@@ -41,7 +41,6 @@
     - vars/csm_repos.yml
     - vars/csm_packages.yml
   roles:
-    - role: trust-csm-ssh-keys
     - role: csm.ca_cert
     - role: csm.packages
       vars:

--- a/ansible/ncn-worker_nodes.yml
+++ b/ansible/ncn-worker_nodes.yml
@@ -41,7 +41,6 @@
     - vars/csm_repos.yml
     - vars/csm_packages.yml
   roles:
-    - role: trust-csm-ssh-keys
     - role: csm.ca_cert
     - role: csm.packages
       vars:

--- a/ansible/ncn_nodes.yml
+++ b/ansible/ncn_nodes.yml
@@ -37,7 +37,6 @@
     - vars/csm_repos.yml
     - vars/csm_packages.yml
   roles:
-    - role: trust-csm-ssh-keys
     - role: csm.ca_cert
     - role: csm.packages
       vars:


### PR DESCRIPTION
## Summary and Scope

It was discovered that a deprecated ansible role was still being referenced by csm-config NCN configuration playbooks. This role does not have an effective use, and should have been replaced in full by the passwordless-ssh role in full.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMCMS-8483](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8483)
* Documentation changes required; link not yet available.


## Testing
### Tested on:

  * `wasp`
  * Local development environment

### Test description:

Backported the effective changes to a custom configuration set on wasp and then executed against a worker node.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
