### PR TITLE
Allow enable-chn.yml to be a no-op during Image Customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- CASMNET-2085: Allow `enable-chn.yml` to be a no-op during Image Customization
+
 ## [1.16.0] - 2023-03-23
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
 - CASMNET-2085: Allow `enable-chn.yml` to be a no-op during Image Customization
 
 ## [1.16.0] - 2023-03-23

--- a/ansible/enable_chn.yml
+++ b/ansible/enable_chn.yml
@@ -22,7 +22,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-- hosts: Management_Worker
+- hosts: Management_Worker:!cfs_image
   gather_facts: yes
   any_errors_fatal: true
   remote_user: root


### PR DESCRIPTION
## Summary and Scope

To facilitate adding `enable-chn.yml` into default bootprep automation files for NCNs, allow `enable-chn.yml` to be a no-op during CFS Image Customization

## Issues and Related PRs

* Resolves [CASMNET-2085](https://jira-pro.its.hpecorp.net:8443/browse/CASMNET-2085)

## Testing

  * `lemondrop`
  
Tested an image build using `sat bootprep`. The additional CFS layer shows up in the image build, but it is skipped. Checked all three NCN image builds (kubernetes-worker, kubernetes-master, storage):
```
Running enable_chn.yml from repo https://api-gw-service-nmn.local/vcs/cray/csm-config-management.git

PLAY [Management_Worker:!cfs_image] ********************************************
skipping: no hosts matched

...

Running enable_chn.yml from repo https://api-gw-service-nmn.local/vcs/cray/csm-config-management.git

PLAY [Management_Worker:!cfs_image] ********************************************
skipping: no hosts matched

...

Running enable_chn.yml from repo https://api-gw-service-nmn.local/vcs/cray/csm-config-management.git
[WARNING]: Could not match supplied host pattern, ignoring: Management_Worker

PLAY [Management_Worker:!cfs_image] ********************************************
skipping: no hosts matched
```

## Risks and Mitigations

The risk is that `hpc-csm-software-recipe` is updated before this change to `csm-config` is in place. To mitigate that, `hpc-csm-software-recipe` will not be updated until a CSM build is available that contains this change.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

