### PR TITLE
MTL-2016 Add `csm-auth-utils` and `noos` repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- MTL-2016: Include `csm-auth-utils` in `csm-packages`
+- CASMINST-3421: Include the new `noos` repository in `csm-repos`
+
 ## [1.16.2] - 2023-03-29
 
 ### Changed

--- a/ansible/vars/csm_packages.yml
+++ b/ansible/vars/csm_packages.yml
@@ -31,5 +31,6 @@ general_csm_sles_packages:
   - cfs-state-reporter
   - craycli
   - cray-uai-util
+  - csm-auth-utils
   - csm-node-identity
   - spire-agent

--- a/ansible/vars/csm_repos.yml
+++ b/ansible/vars/csm_repos.yml
@@ -31,6 +31,9 @@ csm_sles_repositories:
 - name: csm-sle-15sp4
   description: "CSM SLE 15 SP4 Packages (added by Ansible)"
   repo: https://packages.local/repository/csm-sle-15sp4
+- name: csm-noos
+  description: "CSM No-OS Packages (added by Ansible)"
+  repo: https://packages.local/repository/csm-noos
 - name: csm-embedded
   description: "CSM Embedded NCN Packages (added by Ansible)"
   repo: https://packages.local/repository/csm-embedded


### PR DESCRIPTION
Adds the `noos` repo (CASMINST-3421) which provides our new `csm-auth-utils` package from MTL-2016.


Requires these to merge _first_, so the package is available. This could have merged at the same time, but I got this PR up late and can't complete the csm-config merge process right now.