### PR TITLE
CASM-4085: Add csm.ncn.sysctl role

### DIFF
--- a/ansible/roles/csm.ncn.sysctl/README.md
+++ b/ansible/roles/csm.ncn.sysctl/README.md
@@ -1,0 +1,51 @@
+csm.ncn.sysctl
+=========
+
+Set sysctl values.
+
+Requirements
+------------
+
+The sysctl values must exist in configuration prior to running this role. 
+This role must be run in the context of the CSM Configuration
+Framework Service (CFS) in its Ansible Execution Environment (AEE).
+
+Role Variables
+--------------
+
+Available variables are listed below, along with default values (located in
+`defaults/main.yml`):
+
+    sysctl_config: 'dict'
+
+The dict of the sysctl parameters and their values
+
+Dependencies
+------------
+
+None
+
+Example Playbook
+----------------
+
+This role sets the sysctl values in /etc/sysctl.conf and ensures the
+values are currently set by writing directly with systctl -w).
+The role is invoked as shown below for the `foo` user with RSA-type keys:
+
+    - hosts: Management
+      roles:
+        - role: csm.ncn.sysctl
+          vars:
+            sysctl_config:
+              - name: net.ipv4.conf.all.accept_local
+                value: 1
+
+License
+-------
+
+MIT
+
+Author Information
+------------------
+
+Copyright 2021-2024 Hewlett Packard Enterprise Development LP

--- a/ansible/roles/csm.ncn.sysctl/defaults/main.yml
+++ b/ansible/roles/csm.ncn.sysctl/defaults/main.yml
@@ -1,0 +1,47 @@
+#
+# MIT License
+#
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# Defaults for the csm.ncn.sysctl role. See the README.md for information.
+sysctl_config:
+  - name: net.ipv4.conf.all.accept_local
+    value: 0
+  - name: net.ipv4.conf.all.arp_accept
+    value: 0
+  - name: net.ipv4.conf.all.arp_ignore
+    value: 1
+  - name: net.ipv4.conf.all.arp_filter
+    value: 0
+  - name: net.ipv4.conf.all.arp_announce
+    value: 2
+  - name: net.ipv4.conf.all.rp_filter
+    value: 2
+  - name: net.ipv4.neigh.default.gc_interval
+    value: 30
+  - name: net.ipv4.neigh.default.gc_stale_time
+    value: 60
+  - name: net.ipv4.neigh.default.gc_thresh1
+    value: 128
+  - name: net.ipv4.neigh.default.gc_thresh2
+    value: 512
+  - name: net.ipv4.neigh.default.gc_thresh3
+    value: 1024

--- a/ansible/roles/csm.ncn.sysctl/tasks/main.yml
+++ b/ansible/roles/csm.ncn.sysctl/tasks/main.yml
@@ -1,0 +1,30 @@
+# MIT License
+#
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# Tasks for the csm.ncn.sysctl role
+- name: Set sysctl configs in /etc/sysctl.conf
+  sysctl:
+    name: '{{ item.key }}'
+    value: '{{ item.value }}'
+    state: present
+    sysctl_set: true
+  with_dict: '{{ sysctl_config }}'


### PR DESCRIPTION
This is a draft PR to initiate a conversation of what the solution for CASM-4085 should look like.