### PR TITLE
CASM-4085: Add csm.ncn.sysctl role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.16.5] - 2023-06-22
+## [1.16.5] - 2023-06-26
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.16.5] - 2023-06-22
+
+### Added
+
+- CASM-4085: Add sysctl role for modifying kernel parameters
+
 ## [1.16.4] - 2023-06-22
 
 ### Added
@@ -179,7 +185,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ansible playbook for applying csm packages to Compute and Application nodes
 
-[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.16.4...HEAD
+[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.16.5...HEAD
+
+[1.16.5]: https://github.com/Cray-HPE/csm-config/compare/1.16.4...1.16.5
+
+[1.16.4]: https://github.com/Cray-HPE/csm-config/compare/1.16.3...1.16.4
 
 [1.16.4]: https://github.com/Cray-HPE/csm-config/compare/1.16.3...1.16.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,8 +191,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [1.16.4]: https://github.com/Cray-HPE/csm-config/compare/1.16.3...1.16.4
 
-[1.16.4]: https://github.com/Cray-HPE/csm-config/compare/1.16.3...1.16.4
-
 [1.16.3]: https://github.com/Cray-HPE/csm-config/compare/1.16.2...1.16.3
 
 [1.16.2]: https://github.com/Cray-HPE/csm-config/compare/1.16.1...1.16.2

--- a/ansible/ncn-sysctl.yml
+++ b/ansible/ncn-sysctl.yml
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -22,8 +22,8 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-# This is a top level play for all NCN nodes that encorporates all 3 kinds of
-# NCN node (management, storage, worker) as well as their Image counterparts.
+# This is a top level play for all NCNs that incorporates all 3 kinds of
+# NCN (management, storage, worker) as well as their corresponding images.
 # The play runs csm.ncn.sysctl which sets kernel parameters
 - hosts: "Management_Master:Management_Worker:Management_Storage:!cfs_image"
   any_errors_fatal: true

--- a/ansible/ncn-sysctl.yml
+++ b/ansible/ncn-sysctl.yml
@@ -1,0 +1,42 @@
+#!/usr/bin/env ansible-playbook
+#
+# MIT License
+#
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# This is a top level play for all NCN nodes that encorporates all 3 kinds of
+# NCN node (management, storage, worker) as well as their Image counterparts.
+# The play runs csm.ncn.sysctl which sets kernel parameters
+- hosts: "Management_Master:Management_Worker:Management_Storage:!cfs_image"
+  any_errors_fatal: true
+  remote_user: root
+  roles:
+    - role: csm.ncn.sysctl
+      vars:
+        sysctl_set: true
+
+- hosts: &cfs_image
+  any_errors_fatal: true
+  remote_user: root
+  roles:
+    - role: csm.ncn.sysctl
+      vars:
+        sysctl_set: false

--- a/ansible/ncn_nodes.yml
+++ b/ansible/ncn_nodes.yml
@@ -22,8 +22,8 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-# This is a top level play for all NCN nodes that encorporates all 3 kinds of
-# NCN node (management, storage, worker) as well as their Image counterparts.
+# This is a top level play for all NCNs that incorporates all 3 kinds of
+# NCN (management, storage, worker) as well as their corresponding images.
 # The three seperate top level plays are marked for deprecation via a debug
 # notice.
 - hosts:

--- a/ansible/roles/csm.ncn.sysctl/README.md
+++ b/ansible/roles/csm.ncn.sysctl/README.md
@@ -58,4 +58,4 @@ MIT
 Author Information
 ------------------
 
-Copyright 2021-2024 Hewlett Packard Enterprise Development LP
+Copyright 2023 Hewlett Packard Enterprise Development LP

--- a/ansible/roles/csm.ncn.sysctl/README.md
+++ b/ansible/roles/csm.ncn.sysctl/README.md
@@ -13,14 +13,18 @@ Framework Service (CFS) in its Ansible Execution Environment (AEE).
 Role Variables
 --------------
 
-Available variables are listed below, along with default values (located in
+Available variables are listed below, along with example values (located in
 `defaults/main.yml` and `vars/main.yml`):
 
-    sysctl_config: 'dict'
+```yaml
+sysctl_config: 'dict'
+```
 
-The dict of the sysctl parameters and their values.
+The dictionary of the sysctl parameters and their values.
 
-    sysctl_set: false
+```yaml
+sysctl_set: false
+```
 
 Whether to apply this in a running system and reload the values.
 
@@ -32,11 +36,11 @@ None
 Example Playbook
 ----------------
 
-This role sets the kernel parameters in /etc/sysctl.conf. If `sysctl_set` is `true`,
-then the role also ensures the written directly to the system with systctl -w.
+This role sets the kernel parameters in `/etc/sysctl.conf`. If `sysctl_set` is `true`, then
+the role also ensures the parameters are written directly to the system with `systctl -w`.
 Note that the playbook will not work with `sysctl_set` set to `true` if the system
 is not running.
-
+```yaml
     - hosts: Management
       roles:
         - role: csm.ncn.sysctl
@@ -45,7 +49,7 @@ is not running.
             sysctl_config:
               - name: net.ipv4.conf.all.accept_local
                 value: 1
-
+```
 License
 -------
 

--- a/ansible/roles/csm.ncn.sysctl/README.md
+++ b/ansible/roles/csm.ncn.sysctl/README.md
@@ -1,0 +1,57 @@
+csm.ncn.sysctl
+=========
+
+Set kernel parameter values with sysctl.
+
+Requirements
+------------
+
+The values must exist in configuration prior to running this role. 
+This role must be run in the context of the CSM Configuration
+Framework Service (CFS) in its Ansible Execution Environment (AEE).
+
+Role Variables
+--------------
+
+Available variables are listed below, along with default values (located in
+`defaults/main.yml` and `vars/main.yml`):
+
+    sysctl_config: 'dict'
+
+The dict of the sysctl parameters and their values.
+
+    sysctl_set: false
+
+Whether to apply this in a running system and reload the values.
+
+Dependencies
+------------
+
+None
+
+Example Playbook
+----------------
+
+This role sets the kernel parameters in /etc/sysctl.conf. If `sysctl_set` is `true`,
+then the role also ensures the written directly to the system with systctl -w.
+Note that the playbook will not work with `sysctl_set` set to `true` if the system
+is not running.
+
+    - hosts: Management
+      roles:
+        - role: csm.ncn.sysctl
+          vars:
+            sysctl_set: false
+            sysctl_config:
+              - name: net.ipv4.conf.all.accept_local
+                value: 1
+
+License
+-------
+
+MIT
+
+Author Information
+------------------
+
+Copyright 2021-2024 Hewlett Packard Enterprise Development LP

--- a/ansible/roles/csm.ncn.sysctl/defaults/main.yml
+++ b/ansible/roles/csm.ncn.sysctl/defaults/main.yml
@@ -1,0 +1,25 @@
+#
+# MIT License
+#
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# Defaults for the csm.ncn.sysctl role. See the README.md for information.
+sysctl_set: false

--- a/ansible/roles/csm.ncn.sysctl/defaults/main.yml
+++ b/ansible/roles/csm.ncn.sysctl/defaults/main.yml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/ansible/roles/csm.ncn.sysctl/tasks/main.yml
+++ b/ansible/roles/csm.ncn.sysctl/tasks/main.yml
@@ -1,6 +1,6 @@
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/ansible/roles/csm.ncn.sysctl/tasks/main.yml
+++ b/ansible/roles/csm.ncn.sysctl/tasks/main.yml
@@ -1,0 +1,31 @@
+# MIT License
+#
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# Tasks for the csm.ncn.sysctl role
+- name: Set kernel parameters in /etc/sysctl.conf
+  sysctl:
+    name: "{{ item.name }}"
+    value: "{{ item.value }}"
+    state: present
+    reload: "{{ sysctl_set }}"
+    sysctl_set: "{{ sysctl_set }}"
+  loop: "{{ sysctl_config }}"

--- a/ansible/roles/csm.ncn.sysctl/vars/main.yml
+++ b/ansible/roles/csm.ncn.sysctl/vars/main.yml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/ansible/roles/csm.ncn.sysctl/vars/main.yml
+++ b/ansible/roles/csm.ncn.sysctl/vars/main.yml
@@ -1,0 +1,47 @@
+#
+# MIT License
+#
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# Vars for the csm.ncn.sysctl role. See the README.md for information.
+sysctl_config:
+  - name: net.ipv4.conf.all.accept_local
+    value: 0
+  - name: net.ipv4.conf.all.arp_accept
+    value: 0
+  - name: net.ipv4.conf.all.arp_ignore
+    value: 1
+  - name: net.ipv4.conf.all.arp_filter
+    value: 0
+  - name: net.ipv4.conf.all.arp_announce
+    value: 2
+  - name: net.ipv4.conf.all.rp_filter
+    value: 2
+  - name: net.ipv4.neigh.default.gc_interval
+    value: 30
+  - name: net.ipv4.neigh.default.gc_stale_time
+    value: 60
+  - name: net.ipv4.neigh.default.gc_thresh1
+    value: 128
+  - name: net.ipv4.neigh.default.gc_thresh2
+    value: 512
+  - name: net.ipv4.neigh.default.gc_thresh3
+    value: 1024


### PR DESCRIPTION
## Summary and Scope

This PR bring a way to set kernel parameters with sysctl. The role works with both editing images, and running systems.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASM-4085](https://jira-pro.it.hpe.com:8443/browse/CASM-4085)

## Testing

### Tested on:

  * `Mug`

### Test description:

Tested by building images with CFS


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

