### PR TITLE
CASMCMS-8537: Documentation for using IMS Passthrough variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 ansible/inventories
 ansible/vars.json
+ansible/*.retry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- CASMCMS-8537: Documentation and sample role for IMS passthrough variables
 
 ## [1.16.4] - 2023-06-22
 

--- a/ansible/roles/csm.ims-passthrough/README.md
+++ b/ansible/roles/csm.ims-passthrough/README.md
@@ -1,0 +1,55 @@
+csm.ims-passthrough
+=========
+
+IMS exposes several runtime and image customization job setup parameters to ansible through environment variables. These
+variables can be treated like hints about expected hardware targets for an image (like architecture) in the case of
+ambiguity when it is not immediately evident, or obfuscated by software based hardware emulation. These environment
+variables are read as part of normal fact gathering, and can be accessed through the `ansible_vars` parent variable.
+`set_fact` is not required to access them, however it may be desirable to do so when the variables are used frequently
+throughout a playbook.
+
+Exposing this information as environment variables during image customization allows us to cleanly abstract the image
+customization process from more invasive methods, like custom ansible facts, or slower more scale-intensive approaches, 
+like querying the IMS API for job information. Finally, this information is exposed to the running ansible job that 
+needs it, and image customization jobs that do not require insight from these variables should not have to run these
+tasks.
+
+This role is not intended to be imported or used in a production playbook because of the added debug information is
+unnecessary. It is, however, useful during debugging playbooks as a quick smoke test for IMS jail setup functionality.
+
+Requirements
+------------
+
+Must be invoked in the context of an IMS image customization procedure. If associated role tasks are run during node
+personalization, the exposed IMS variables will not be able to be read. Standard fact gathering is required to read this
+information from the IMS image chroot environment.
+
+Dependencies
+------------
+
+None.
+
+Example Playbooks
+----------------
+
+    - hosts: Compute:Application:&cfs_image
+      gather_facts: true
+      roles:
+         - role: csm.ims-passthrough
+
+    - hosts: Compute:Application:&cfs_image
+      gather_facts: true
+      tasks:
+        - name: Display IMS passthrough variables as captured through gathered facts
+         [ Content Redacted; use csm.ims-passthrough/tasks/main.yml for the actual task definition]
+
+
+License
+-------
+
+MIT
+
+Author Information
+------------------
+
+Copyright 2023 Hewlett Packard Enterprise Development LP

--- a/ansible/roles/csm.ims-passthrough/tasks/main.yml
+++ b/ansible/roles/csm.ims-passthrough/tasks/main.yml
@@ -1,0 +1,33 @@
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# Tasks for the csm.ims-passhthrough role
+- name: Display IMS passthrough variables as captured through gathered facts
+  set_fact:
+    IMS_JOB_ID: "{{ ansible_env.IMS_JOB_ID|default('') }}"
+    IMS_ARCH: "{{ ansible_env.IMS_ARCH |default('') }}"
+    IMS_DKMS_ENABLED: "{{ ansible_env.IMS_DKMS_ENABLED|default('') }}"
+
+- name: Display all IMS specific variables
+  debug:
+    msg: "IMS_JOB_ID: {{ IMS_JOB_ID }} IMS_ARCH: {{ IMS_ARCH }} IMS_DKMS_ENABLED: {{ IMS_DKMS_ENABLED }}"


### PR DESCRIPTION
Included is documentation and a sample role demonstrating proper lookup of environment variables populated by IMS Chroot Jails.

## Summary and Scope

IMS exposes 3 additional environment variables when standing up a chroot environment for an image. Downstream product setup environments should dynamically change as a function of how these environment variables are set up, for both DKMS and ansible architecture support.

The included new role primarily serves as documentation for best case use and lookup of this exposed information.

## Issues and Related PRs

* Resolves [CASMCMS-8537](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8537)
* Change will also be needed in a newly cut release.

## Testing
### Tested on:

  * `mug` and `tyr`
  * Local development environment

### Test description:

A new test top level playbook was created and run against various host environments; both including and not including environment variables as published. Environment variables specified in this play either correctly displayed the exposed variables or correctly defaulted to the null string, indicating they were not set.

## Risks and Mitigations

Very low risk.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

