### PR TITLE
CASMINST-6532: Add RPMs to list that are installed/updated on nodes; fix default variable value in csm.packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.15.13] - 2023-07-05
+
+### Changed
+
+- CASMINST-6532: Add the following packages to the list that are installed/updated on NCNs in `csm_packages`:
+  - `cfs-state-reporter`
+  - `cfs-trust`
+  - `craycli`
+  - `csm-node-identity`
+  - `csm-testing`
+  - `goss-servers`
+  - `hpe-csm-goss-package`
+  - `hpe-csm-scripts`
+  - `hpe-csm-yq-package`
+  - `manifestgen`
+- CASMINST-6532: Add the following packages to the list that are installed/updated on Compute nodes in `csm_packages`:
+  - `csm-node-identity`
+
 ## [1.15.12] - 2023-03-29
 
 ### Changed
@@ -131,7 +149,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ansible playbook for applying csm packages to Compute and Application nodes
 
-[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.15.12...HEAD
+[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.15.13...HEAD
+
+[1.15.13]: https://github.com/Cray-HPE/csm-config/compare/1.15.12...1.15.13
 
 [1.15.12]: https://github.com/Cray-HPE/csm-config/compare/1.15.11...1.15.12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CASMINST-6532: Add the following packages to the list that are installed/updated on Compute nodes in `csm_packages`:
   - `csm-node-identity`
 
+### Fixed
+
+- CASMINST-6532: Ansible role `csm.packages`: Corrected default value for repository list to be an empty list, not an empty dictionary.
+
 ## [1.15.12] - 2023-03-29
 
 ### Changed

--- a/ansible/roles/csm.packages/README.md
+++ b/ansible/roles/csm.packages/README.md
@@ -15,14 +15,18 @@ Role Variables
 Available variables are listed below, along with default values (located in
 `defaults/main.yml`):
 
-    csm_sles_repositories: {}
+```yaml
+    csm_sles_repositories: []
+```
 
 List of SUSE Linux Enterprise Server repositories to install. See example below
 for mapping keys. These keys are directly used with the Ansible `zypper_repository`
 module. The `name`, `description`, `repo`, and `disable_gpg_check` fields are
 supported.
 
+```yaml
     csm_sles_packages: []
+```
 
 List of packages to install.
 
@@ -36,6 +40,7 @@ default, i.e. `disable_gpg_check: no`).
 Example Playbook
 ----------------
 
+```yaml
     - hosts: Management_Master
       roles:
          - role: csm.packages
@@ -48,6 +53,7 @@ Example Playbook
                  description: CSM SUSE Linux Enterprise 15 SP2 Packages
                  repo: https://packages.local/repositories/csm-sle-15sp2
                  disable_gpg_check: no
+```
 
 License
 -------
@@ -57,4 +63,4 @@ MIT
 Author Information
 ------------------
 
-Copyright 2021 Hewlett Packard Enterprise Development LP
+Copyright 2021, 2023 Hewlett Packard Enterprise Development LP

--- a/ansible/roles/csm.packages/defaults/main.yml
+++ b/ansible/roles/csm.packages/defaults/main.yml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -23,5 +23,5 @@
 #
 # Defaults for the csm.packages role. See the README.md for information.
 csm_sles_packages: []
-csm_sles_repositories: {}
+csm_sles_repositories: []
 

--- a/ansible/vars/csm_packages.yml
+++ b/ansible/vars/csm_packages.yml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -21,13 +21,27 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-ncn_csm_sles_packages:
-  - cray-cmstools-crayctldeploy
-  - loftsman
-  - cfs-debugger
 
+# List of packages to be installed/updated from Nexus on all Management NCNs
+ncn_csm_sles_packages:
+  - cfs-debugger
+  - cfs-state-reporter
+  - cfs-trust
+  - craycli
+  - cray-cmstools-crayctldeploy
+  - csm-node-identity
+  - csm-testing
+  - goss-servers
+  - hpe-csm-goss-package
+  - hpe-csm-scripts
+  - hpe-csm-yq-package
+  - loftsman
+  - manifestgen
+
+# List of packages to be installed/updated from Nexus on all Compute nodes
 general_csm_sles_packages:
   - bos-reporter
   - cfs-state-reporter
   - craycli
   - cray-uai-util
+  - csm-node-identity


### PR DESCRIPTION
## Summary and Scope

The CSM 1.4.1 patch included a new version of the Cray CLI RPM, but it did not get updated on the NCNs even though it was in Nexus and CFS was re-run on the NCNs. It turns out that this RPM is updated on compute nodes by CFS but not NCNs.

This PR adds the Cray CLI RPM to the list of packages that are installed/updated on NCNs. It also includes a few other RPMs that should be updated from Nexus on NCNs, if there are updates available -- the Goss test RPMs, `cfs-state-reporter`, `cfs-trust`, and a few others. I verified that all of these RPMs are listed in the CSM manifests both for Nexus and for the node images.

This also fixes the `csm.packages` role to use the correct default value for the repository list. Previously it defaulted to an empty dictionary, but it is expected to be a list, and Ansible fails if you try to use it with the default value of an empty dictionary.

## Issues and Related PRs

* Resolves [CASMINST-6532](https://jira-pro.it.hpe.com:8443/browse/CASMINST-6532) for CSM 1.4
* [develop branch PR to handle this for CSM 1.5](https://github.com/Cray-HPE/csm-config/pull/143)
* Needed in order to include [CASMCMS-8599](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8599) in CSM 1.4

## Testing

I manually updated csm-config on bradi and verified that it worked properly.

## Risks and Mitigations

Low risk. Just adding RPMs to the existing list.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
