### PR TITLE
CASMINST-6532: Add RPMs to lists that are installed/updated on nodes; fix default variable value in csm.packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.16.7] - 2023-07-05
+
 ### Changed
 
 - CASMINST-6532: Split the `csm_packages` lists into `common_csm_sles_packages` (installed on all SLES nodes),
@@ -219,7 +221,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ansible playbook for applying csm packages to Compute and Application nodes
 
-[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.16.6...HEAD
+[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.16.7...HEAD
+
+[1.16.7]: https://github.com/Cray-HPE/csm-config/compare/1.16.6...1.16.7
 
 [1.16.6]: https://github.com/Cray-HPE/csm-config/compare/1.16.5...1.16.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CASMINST-6532: Moved `cmstools` to the `k8s_ncn_csm_sles_packages` list so that it would not be installed on
   storage NCNs, where it does not work.
 
+### Fixed
+
+- CASMINST-6532: Ansible role `csm.packages`: Corrected default value for repository list to be an empty list, not an empty dictionary.
+
 ## [1.16.6] - 2023-06-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- CASMINST-6532: Split the `csm_packages` lists into `common_csm_sles_packages` (installed on all SLES nodes),
+  `ncn_csm_sles_packages` (installed on all management NCNs), `k8s_ncn_csm_sles_packages` (installed on all
+  master/worker NCNs), and `compute_csm_sles_packages` (installed on all SLES application and compute nodes).
+  Modified the plays accordingly.
+- CASMINST-6532: Added some RPMs that were missing from the NCN list:
+  - `cfs-state-reporter`
+  - `cfs-trust`
+  - `craycli`
+  - `csm-auth-utils`
+  - `csm-node-heartbeat`
+  - `csm-node-identity`
+  - `csm-testing`
+  - `goss-servers`
+  - `hpe-csm-goss-package`
+  - `hpe-csm-scripts`
+  - `hpe-yq`
+  - `manifestgen`
+  - `spire-agent`
+- CASMINST-6532: Moved `cmstools` to the `k8s_ncn_csm_sles_packages` list so that it would not be installed on
+  storage NCNs, where it does not work.
+
 ## [1.16.6] - 2023-06-28
+
 ### Added
+
 - CASMCMS-8537: Documentation and sample role for IMS passthrough variables
 
 ## [1.16.5] - 2023-06-26
@@ -20,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.16.4] - 2023-06-22
 
 ### Added
+
 - MTL-2018: Include `acpid`
 - MTL-2019: Include `csm-node-heartbeat`
 
@@ -189,7 +215,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ansible playbook for applying csm packages to Compute and Application nodes
 
-[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.16.5...HEAD
+[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.16.6...HEAD
+
+[1.16.6]: https://github.com/Cray-HPE/csm-config/compare/1.16.5...1.16.6
 
 [1.16.5]: https://github.com/Cray-HPE/csm-config/compare/1.16.4...1.16.5
 

--- a/ansible/csm_packages.yml
+++ b/ansible/csm_packages.yml
@@ -39,7 +39,7 @@
     # Install CSM repositories and packages
     - role: csm.packages
       vars:
-        packages: "{{ general_csm_sles_packages }}"
+        packages: "{{ common_csm_sles_packages + compute_csm_sles_packages }}"
       when: ansible_distribution == "SLES"
   tasks:
     - name: Add reporters to presets file

--- a/ansible/ncn-master_nodes.yml
+++ b/ansible/ncn-master_nodes.yml
@@ -45,7 +45,7 @@
     - role: csm.ca_cert
     - role: csm.packages
       vars:
-        packages: "{{ ncn_csm_sles_packages }}"
+        packages: "{{ common_csm_sles_packages + ncn_csm_sles_packages + k8s_ncn_csm_sles_packages }}"
       when: ansible_os_family == "SLE_HPC"
     - role: passwordless-ssh
     - role: csm.password

--- a/ansible/ncn-storage_nodes.yml
+++ b/ansible/ncn-storage_nodes.yml
@@ -45,7 +45,7 @@
     - role: csm.ca_cert
     - role: csm.packages
       vars:
-        packages: "{{ ncn_csm_sles_packages }}"
+        packages: "{{ common_csm_sles_packages + ncn_csm_sles_packages }}"
       when: ansible_os_family == "SLE_HPC"
     - role: passwordless-ssh
     - role: csm.password

--- a/ansible/ncn-worker_nodes.yml
+++ b/ansible/ncn-worker_nodes.yml
@@ -45,7 +45,7 @@
     - role: csm.ca_cert
     - role: csm.packages
       vars:
-        packages: "{{ ncn_csm_sles_packages }}"
+        packages: "{{ common_csm_sles_packages + ncn_csm_sles_packages + k8s_ncn_csm_sles_packages }}"
       when: ansible_os_family == "SLE_HPC"
     - role: passwordless-ssh
     - role: csm.password

--- a/ansible/ncn_nodes.yml
+++ b/ansible/ncn_nodes.yml
@@ -41,7 +41,7 @@
     - role: csm.ca_cert
     - role: csm.packages
       vars:
-        packages: "{{ ncn_csm_sles_packages }}"
+        packages: "{{ common_csm_sles_packages + ncn_csm_sles_packages }}"
       when: ansible_os_family == "SLE_HPC"
     - role: passwordless-ssh
     - role: csm.password
@@ -50,3 +50,18 @@
     - role: csm.ssh_keys
       vars:
         ssh_keys_username: 'root'
+
+# Roles specific to Kubernetes NCNs (masters and workers)
+- hosts:
+   - Management_Master
+   - Management_Worker
+  gather_facts: yes
+  any_errors_fatal: true
+  remote_user: root
+  vars_files:
+    - vars/csm_packages.yml
+  roles:
+    - role: csm.packages
+      vars:
+        packages: "{{ k8s_ncn_csm_sles_packages }}"
+      when: ansible_os_family == "SLE_HPC"

--- a/ansible/packages.yml
+++ b/ansible/packages.yml
@@ -35,5 +35,5 @@
     # Install CSM repositories and packages
     - role: csm.packages
       vars:
-        packages: "{{ ncn_csm_sles_packages }}"
+        packages: "{{ common_csm_sles_packages + ncn_csm_sles_packages }}"
       when: ansible_os_family == "SLE_HPC"

--- a/ansible/roles/csm.packages/README.md
+++ b/ansible/roles/csm.packages/README.md
@@ -15,14 +15,18 @@ Role Variables
 Available variables are listed below, along with default values (located in
 `defaults/main.yml`):
 
-    csm_sles_repositories: {}
+```yaml
+    csm_sles_repositories: []
+```
 
 List of SUSE Linux Enterprise Server repositories to install. See example below
 for mapping keys. These keys are directly used with the Ansible `zypper_repository`
 module. The `name`, `description`, `repo`, and `disable_gpg_check` fields are
 supported.
 
+```yaml
     csm_sles_packages: []
+```
 
 List of packages to install.
 
@@ -36,6 +40,7 @@ default, i.e. `disable_gpg_check: no`).
 Example Playbook
 ----------------
 
+```yaml
     - hosts: Management_Master
       roles:
          - role: csm.packages
@@ -48,6 +53,7 @@ Example Playbook
                  description: CSM SUSE Linux Enterprise 15 SP2 Packages
                  repo: https://packages.local/repositories/csm-sle-15sp2
                  disable_gpg_check: no
+```
 
 License
 -------

--- a/ansible/roles/csm.packages/defaults/main.yml
+++ b/ansible/roles/csm.packages/defaults/main.yml
@@ -23,5 +23,5 @@
 #
 # Defaults for the csm.packages role. See the README.md for information.
 csm_sles_packages: []
-csm_sles_repositories: {}
+csm_sles_repositories: []
 

--- a/ansible/vars/csm_packages.yml
+++ b/ansible/vars/csm_packages.yml
@@ -21,18 +21,35 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-ncn_csm_sles_packages:
-  - cray-cmstools-crayctldeploy
-  - loftsman
-  - cfs-debugger
 
-general_csm_sles_packages:
-  - acpid
-  - bos-reporter
+# List of packages to be installed/updated from Nexus on all nodes
+# (Management NCNs, Application nodes, and Compute nodes)
+common_csm_sles_packages:
   - cfs-state-reporter
   - craycli
-  - cray-uai-util
   - csm-auth-utils
   - csm-node-heartbeat
   - csm-node-identity
   - spire-agent
+
+# List of packages to be installed/updated from Nexus on all Management NCNs
+ncn_csm_sles_packages:
+  - cfs-debugger
+  - cfs-trust
+  - csm-testing
+  - goss-servers
+  - hpe-csm-goss-package
+  - hpe-csm-scripts
+  - hpe-yq
+  - loftsman
+  - manifestgen
+
+# List of packages to be installed/updated from Nexus on all Kubernetes NCNs
+k8s_ncn_csm_sles_packages:
+  - cray-cmstools-crayctldeploy
+
+# List of packages to be installed/updated from Nexus on all Application and Compute nodes
+compute_csm_sles_packages:
+  - acpid
+  - bos-reporter
+  - cray-uai-util


### PR DESCRIPTION
This is essentially a backport of https://github.com/Cray-HPE/csm-config/pull/142, with:
* some minor RPM content differences because this is CSM 1.5. 
* splitting up the RPM list into multiple lists to more easily see what is being installed where, and to allow more control when adding new RPMs to the lists (I think some of the missing RPMs on NCNs were caused by confusion about where the package lists would be applied)