### PR TITLE
CASMMON-333: Ansible playbook changes for getting SMART data for upgrade to csm-1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.16.10] - 2023-07-28
+
+### Added
+
+- CASMMON-333
+  -  New package `storage_mgmt_ncn_csm_sles_packages` for including new `smart-mon` rpm.
+  -  New role `csm.storage.smartmon` to start smart service, reconfigure and redeploy node_exporter.
+
 ### Changed
 
 - Modified `compute_nodes.yml` top-level play to actually include compute nodes (instead of just application nodes)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - CASMMON-333
-  -  New package `storage_mgmt_ncn_csm_sles_packages` for including new `smart-mon` rpm.
-  -  New role `csm.storage.smartmon` to start smart service, reconfigure and redeploy node_exporter.
+  -  New package `storage_mgmt_ncn_csm_sles_packages` for including new `smart-mon` RPM.
+  -  New role `csm.storage.smartmon` to start the SMART service; reconfigure and redeploy `node-exporter`.
 
 ### Changed
 
@@ -250,7 +250,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ansible playbook for applying csm packages to Compute and Application nodes
 
-[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.16.9...HEAD
+[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.16.10...HEAD
+
+[1.16.10]: https://github.com/Cray-HPE/csm-config/compare/1.16.9...1.16.10
 
 [1.16.9]: https://github.com/Cray-HPE/csm-config/compare/1.16.8...1.16.9
 

--- a/ansible/ncn-storage_nodes.yml
+++ b/ansible/ncn-storage_nodes.yml
@@ -45,7 +45,7 @@
     - role: csm.ca_cert
     - role: csm.packages
       vars:
-        packages: "{{ common_csm_sles_packages + common_mgmt_ncn_csm_sles_packages }}"
+        packages: "{{ common_csm_sles_packages + common_mgmt_ncn_csm_sles_packages + storage_mgmt_ncn_csm_sles_packages }}"
       when: ansible_os_family == "SLE_HPC"
     - role: passwordless-ssh
     - role: csm.password
@@ -54,4 +54,4 @@
     - role: csm.ssh_keys
       vars:
         ssh_keys_username: 'root'
-
+    - role: csm.storage.smartmon

--- a/ansible/ncn_nodes.yml
+++ b/ansible/ncn_nodes.yml
@@ -72,5 +72,8 @@
   roles:
     - role: csm.packages
       vars:
-        packages: "{{ common_csm_sles_packages + common_mgmt_ncn_csm_sles_packages }}"
+        packages: "{{ common_csm_sles_packages + common_mgmt_ncn_csm_sles_packages + storage_mgmt_ncn_csm_sles_packages }}"
       when: ansible_os_family == "SLE_HPC"
+
+    - role: csm.storage.smartmon
+      

--- a/ansible/ncn_nodes.yml
+++ b/ansible/ncn_nodes.yml
@@ -74,6 +74,4 @@
       vars:
         packages: "{{ common_csm_sles_packages + common_mgmt_ncn_csm_sles_packages + storage_mgmt_ncn_csm_sles_packages }}"
       when: ansible_os_family == "SLE_HPC"
-
     - role: csm.storage.smartmon
-      

--- a/ansible/roles/csm.storage.smartmon/README.md
+++ b/ansible/roles/csm.storage.smartmon/README.md
@@ -1,0 +1,40 @@
+csm.storage.smartmon
+=========
+
+Start the smart service, reconfigure and redeploy node_exporter.
+
+Requirements
+------------
+
+None 
+
+Role Variables
+--------------
+
+None
+
+Dependencies
+------------
+
+None
+
+Example Playbook
+----------------
+
+This role starts the smart service on all the storage nodes and reconfigures and redeploys the running node_exporter with new applied configurations. 
+
+```yaml
+- hosts: Management
+  roles:
+     - role: csm.storage.smartmon
+```
+License
+-------
+
+MIT
+
+Author Information
+------------------
+
+Copyright 2023 Hewlett Packard Enterprise Development LP
+

--- a/ansible/roles/csm.storage.smartmon/README.md
+++ b/ansible/roles/csm.storage.smartmon/README.md
@@ -1,7 +1,7 @@
 csm.storage.smartmon
 =========
 
-Start the smart service, reconfigure and redeploy node_exporter.
+Start the SMART service; reconfigure and redeploy `node-exporter`.
 
 Requirements
 ------------
@@ -21,13 +21,17 @@ None
 Example Playbook
 ----------------
 
-This role starts the smart service on all the storage nodes and reconfigures and redeploys the running node_exporter with new applied configurations. 
+This role runs on all the storage NCNs. It starts the SMART service, and reconfigures and redeploys
+the running `node-exporter` (to use changed configurations, if any).
 
 ```yaml
-- hosts: Management
+- hosts: Management_Storage
+  any_errors_fatal: true
+  remote_user: root
   roles:
      - role: csm.storage.smartmon
 ```
+
 License
 -------
 

--- a/ansible/roles/csm.storage.smartmon/tasks/main.yml
+++ b/ansible/roles/csm.storage.smartmon/tasks/main.yml
@@ -1,0 +1,37 @@
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# Tasks for the csm.storage.smartmon role
+- name: Start SMART service
+  become: true
+  systemd:
+    name: smart
+    enabled: yes
+    state: started
+
+- name: Redeploy node-exporter
+  command: "ceph orch {{ item }} "
+  with_items:
+  - apply -i /etc/cray/ceph/node-exporter.yaml
+  - reconfig node-exporter
+  - redeploy node-exporter

--- a/ansible/vars/csm_packages.yml
+++ b/ansible/vars/csm_packages.yml
@@ -22,8 +22,9 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
-# List of packages to be installed/updated from Nexus on all nodes
-# (Management NCNs, Application nodes, and Compute nodes)
+# Lists of packages to be installed/updated from Nexus on nodes of different types
+
+# All nodes (Management NCNs, Application nodes, and Compute nodes)
 common_csm_sles_packages:
   - cfs-state-reporter
   - craycli
@@ -32,8 +33,7 @@ common_csm_sles_packages:
   - csm-node-identity
   - spire-agent
 
-# List of packages to be installed/updated from Nexus on all Management NCNs
-# (master, storage, and worker)
+# All Management NCNs (master, storage, and worker)
 common_mgmt_ncn_csm_sles_packages:
   - cfs-debugger
   - cfs-trust
@@ -45,17 +45,16 @@ common_mgmt_ncn_csm_sles_packages:
   - loftsman
   - manifestgen
 
-# List of packages to be installed/updated from Nexus on all Kubernetes Management NCNs
-# (master and worker)
+# All Kubernetes Management NCNs (master and worker)
 k8s_mgmt_ncn_csm_sles_packages:
   - cray-cmstools-crayctldeploy
 
-# List of packages to be installed/updated from Nexus on all Application and Compute nodes
+# All storage Management NCNs
+storage_mgmt_ncn_csm_sles_packages:
+  - smart-mon
+
+# All Application and Compute nodes
 compute_csm_sles_packages:
   - acpid
   - bos-reporter
   - cray-uai-util
-
-# List of packages to be installed/updated from Nexus on all storage Management NCNs
-storage_mgmt_ncn_csm_sles_packages:
-  - smart-mon

--- a/ansible/vars/csm_packages.yml
+++ b/ansible/vars/csm_packages.yml
@@ -55,3 +55,7 @@ compute_csm_sles_packages:
   - acpid
   - bos-reporter
   - cray-uai-util
+
+# List of packages to be installed/updated from Nexus on all storage Management NCNs
+storage_mgmt_ncn_csm_sles_packages:
+  - smart-mon


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves - 
https://jira-pro.it.hpe.com:8443/browse/CASMMON-333

## Testing

_List the environments in which these changes were tested._

### Tested on:

Mug

### Test description:

ncn-m001:~/shreni # kubectl logs -n services jobs/cfs-2f6c447c-dc65-47db-8909-07a136422913 ansible
Inventory generation completed
SSH keys migrated to /root/.ssh
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
HTTP/1.1 200 OK
content-type: text/html; charset=UTF-8
cache-control: no-cache, max-age=0
x-content-type-options: nosniff
date: Thu, 27 Jul 2023 06:19:13 GMT
server: envoy
transfer-encoding: chunked

Sidecar available
Running ncn_nodes.yml from repo https://api-gw-service-nmn.local/vcs/cray/csm-config-management.git

PLAY [Management_Master,Management_Worker,Management_Storage] ******************

TASK [trust-csm-ssh-keys : Inject CSM public Key into SSH authorized_keys file] ***
changed: [x3000c0s13b0n0]

TASK [passwordless-ssh : Write private keyfile to disk with appropriate permissions] ***
changed: [x3000c0s13b0n0]

TASK [passwordless-ssh : Create the CSM public key file on target hosts] *******
changed: [x3000c0s13b0n0]

TASK [csm.password : Lookup the password value in Vault] ***********************
fatal: [x3000c0s13b0n0]: FAILED! => {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result"}

TASK [csm.ssh_keys : Lookup the private key value in Vault] ********************
fatal: [x3000c0s13b0n0]: FAILED! => {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result"}

TASK [csm.ssh_keys : Lookup the public key value in Vault] *********************
fatal: [x3000c0s13b0n0]: FAILED! => {"msg": "An unhandled exception occurred while running the lookup plugin 'hashi_vault'. Error was a <class 'ansible.errors.AnsibleError'>, original message: The secret secret/csm/users/root doesn't seem to exist for hashi_vault lookup"}

PLAY [Management_Master,Management_Worker] *************************************
skipping: no hosts matched

PLAY [Management_Storage] ******************************************************

TASK [csm.packages : Allow unsigned repo metadata] *****************************
changed: [x3000c0s13b0n0] => (item={'name': 'csm-sle-15sp2', 'description': 'CSM SLE 15 SP2 Packages (added by Ansible)', 'repo': 'https://packages.local/repository/csm-sle-15sp2'})
changed: [x3000c0s13b0n0] => (item={'name': 'csm-sle-15sp3', 'description': 'CSM SLE 15 SP3 Packages (added by Ansible)', 'repo': 'https://packages.local/repository/csm-sle-15sp3'})
changed: [x3000c0s13b0n0] => (item={'name': 'csm-sle-15sp4', 'description': 'CSM SLE 15 SP4 Packages (added by Ansible)', 'repo': 'https://packages.local/repository/csm-sle-15sp4'})
changed: [x3000c0s13b0n0] => (item={'name': 'csm-noos', 'description': 'CSM No-OS Packages (added by Ansible)', 'repo': 'https://packages.local/repository/csm-noos'})
changed: [x3000c0s13b0n0] => (item={'name': 'csm-embedded', 'description': 'CSM Embedded NCN Packages (added by Ansible)', 'repo': 'https://packages.local/repository/csm-embedded'})

TASK [csm.storage.smartmon : Install RPMs (SLES-based)] ************************
changed: [x3000c0s13b0n0]

TASK [csm.storage.smartmon : Restart SMART service] ****************************
changed: [x3000c0s13b0n0]

TASK [csm.storage.smartmon : Apply ceph orch] **********************************
changed: [x3000c0s13b0n0] => (item=apply -i /etc/cray/ceph/node-exporter.yml)
changed: [x3000c0s13b0n0] => (item=reconfig node-exporter)
changed: [x3000c0s13b0n0] => (item=redeploy node-exporter)

PLAY RECAP *********************************************************************
x3000c0s13b0n0             : ok=20   changed=7    unreachable=0    failed=0    skipped=5    rescued=3    ignored=0

All playbooks completed successfully

=================================================================================

ncn-s001:/var/lib/node_exporter # curl localhost:9100/metrics | grep smart
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0node_textfile_mtime_seconds{file="smartmon.prom"} 1.690438803e+09
 HELP smartmon_airflow_temperature_cel_raw_value SMART metric airflow_temperature_cel_raw_value
 TYPE smartmon_airflow_temperature_cel_raw_value gauge
smartmon_airflow_temperature_cel_raw_value{disk="/dev/sda",smart_id="190",type="sat"} 23
smartmon_airflow_temperature_cel_raw_value{disk="/dev/sdb",smart_id="190",type="sat"} 23
smartmon_airflow_temperature_cel_raw_value{disk="/dev/sdc",smart_id="190",type="sat"} 23
smartmon_airflow_temperature_cel_raw_value{disk="/dev/sdd",smart_id="190",type="sat"} 23
smartmon_airflow_temperature_cel_raw_value{disk="/dev/sde",smart_id="190",type="sat"} 23
smartmon_airflow_temperature_cel_raw_value{disk="/dev/sdf",smart_id="190",type="sat"} 22
smartmon_airflow_temperature_cel_raw_value{disk="/dev/sdg",smart_id="190",type="sat"} 23
smartmon_airflow_temperature_cel_raw_value{disk="/dev/sdh",smart_id="190",type="sat"} 23


