### PR TITLE
Fix node-exporter filename extension (CASMTRIAGE-5793)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - CASMTRIAGE-5793
-  -  Fix node-exporter filename extension
+  -  Fix `node-exporter` filename extension in [`ansible/roles/csm.storage.smartmon/tasks/main.yml`](ansible/roles/csm.storage.smartmon/tasks/main.yml)
 
 ## [1.16.10] - 2023-07-28
 
@@ -257,7 +257,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ansible playbook for applying csm packages to Compute and Application nodes
 
-[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.16.10...HEAD
+[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.16.11...HEAD
+
+[1.16.11]: https://github.com/Cray-HPE/csm-config/compare/1.16.10...1.16.11
 
 [1.16.10]: https://github.com/Cray-HPE/csm-config/compare/1.16.9...1.16.10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.16.11] - 2023-08-01
+
+### Added
+
+- CASMTRIAGE-5793
+  -  Fix node-exporter filename extension
+
 ## [1.16.10] - 2023-07-28
 
 ### Added

--- a/ansible/roles/csm.storage.smartmon/tasks/main.yml
+++ b/ansible/roles/csm.storage.smartmon/tasks/main.yml
@@ -32,6 +32,6 @@
 - name: Redeploy node-exporter
   command: "ceph orch {{ item }} "
   with_items:
-  - apply -i /etc/cray/ceph/node-exporter.yaml
+  - apply -i /etc/cray/ceph/node-exporter.yml
   - reconfig node-exporter
   - redeploy node-exporter


### PR DESCRIPTION
### Summary and Scope

Fix filename extension for node-exporter yaml.

### Issues and Related PRs

* https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5793

### Testing

Fanta re-running play with file renamed:

```
root@ncn-m001 2023-08-01 14:47:05 ~ # /usr/share/doc/csm/scripts/operations/configuration/apply_csm_configuration.sh --config-name "management-csm-${CSM_RELEASE}" --clear-state --xnames x3000c0s15b0n0,x3000c0s13b0n0,x3000c0s17b0n0
Using latest release 1.5.0-beta.29
Using CSM configuration version 1.16.10
Found git commit eb2eb80f88b3e70c9b5636af2a5b3ee4b119b3d3
Creating the configuration file /root/apply_csm_configuration.20230801_145050.Us9FhC/csm-config-1.16.10-F4XQ7H.json
Creating new NCN configuration file /root/apply_csm_configuration.20230801_145050.Us9FhC/new-management-csm-1.5.0-44uWfp.json
Disabling configuration for all listed components
desiredConfig = "management-csm-1.5.0"
enabled = false
errorCount = 3
id = "x3000c0s15b0n0"
[[state]]
cloneUrl = "https://api-gw-service-nmn.local/vcs/cray/csm-config-management.git"
commit = "eb2eb80f88b3e70c9b5636af2a5b3ee4b119b3d3_failed"
lastUpdated = "2023-08-01T14:27:21Z"
playbook = "site.yml"
sessionName = "batcher-d5ee46b3-3118-471e-8a65-b3b63976189a"

[tags]

desiredConfig = "management-csm-1.5.0"
enabled = false
errorCount = 3
id = "x3000c0s13b0n0"
[[state]]
cloneUrl = "https://api-gw-service-nmn.local/vcs/cray/csm-config-management.git"
commit = "eb2eb80f88b3e70c9b5636af2a5b3ee4b119b3d3_failed"
lastUpdated = "2023-08-01T14:27:21Z"
playbook = "site.yml"
sessionName = "batcher-d5ee46b3-3118-471e-8a65-b3b63976189a"

[tags]

desiredConfig = "management-csm-1.5.0"
enabled = false
errorCount = 3
id = "x3000c0s17b0n0"
[[state]]
cloneUrl = "https://api-gw-service-nmn.local/vcs/cray/csm-config-management.git"
commit = "eb2eb80f88b3e70c9b5636af2a5b3ee4b119b3d3_failed"
lastUpdated = "2023-08-01T14:27:21Z"
playbook = "site.yml"
sessionName = "batcher-d5ee46b3-3118-471e-8a65-b3b63976189a"

[tags]

Backing up existing management-csm-1.5.0 configuration (if any) to /root/apply_csm_configuration.20230801_145050.Us9FhC/backup-management-csm-1.5.0-YVNZbH.json
Updating management-csm-1.5.0 configuration
lastUpdated = "2023-08-01T14:50:55Z"
name = "management-csm-1.5.0"
[[layers]]
cloneUrl = "https://api-gw-service-nmn.local/vcs/cray/csm-config-management.git"
commit = "eb2eb80f88b3e70c9b5636af2a5b3ee4b119b3d3"
name = "csm-1.16.10"
playbook = "site.yml"


Setting desired configuration, clearing state, clearing error count, enabling components in CFS
desiredConfig = "management-csm-1.5.0"
enabled = true
errorCount = 0
id = "x3000c0s15b0n0"
state = []

[tags]

desiredConfig = "management-csm-1.5.0"
enabled = true
errorCount = 0
id = "x3000c0s13b0n0"
state = []

[tags]

desiredConfig = "management-csm-1.5.0"
enabled = true
errorCount = 0
id = "x3000c0s17b0n0"
state = []

[tags]

Waiting for configuration to complete.  3 components remaining.
Waiting for configuration to complete.  3 components remaining.
Configuration complete. 3 component(s) completed successfully.  0 component(s) failed.
root@ncn-m001 2023-08-01 14:53:01 ~ #
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
