### PR TITLE
CASMTRIAGE-5788 Use Pre CSM 1.4 Defaults for ARP sysctl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.16.12] - 2023-08-03
+
+### Added
+
+- CASMTRIAGE-5788
+  -  Use `sysctl` defaults removed by MTL-1974 to [`ansible/roles/csm.ncn.sysctl/vars/main.yml`](ansible/roles/csm.ncn.sysctl/vars/main.yml)
+
 ## [1.16.11] - 2023-08-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -264,7 +264,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ansible playbook for applying csm packages to Compute and Application nodes
 
-[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.16.11...HEAD
+[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.16.12...HEAD
+
+[1.16.12]: https://github.com/Cray-HPE/csm-config/compare/1.16.11...1.16.12
 
 [1.16.11]: https://github.com/Cray-HPE/csm-config/compare/1.16.10...1.16.11
 

--- a/ansible/roles/csm.ncn.sysctl/vars/main.yml
+++ b/ansible/roles/csm.ncn.sysctl/vars/main.yml
@@ -38,10 +38,10 @@ sysctl_config:
   - name: net.ipv4.neigh.default.gc_interval
     value: 30
   - name: net.ipv4.neigh.default.gc_stale_time
-    value: 60
+    value: 240
   - name: net.ipv4.neigh.default.gc_thresh1
-    value: 128
+    value: 2048
   - name: net.ipv4.neigh.default.gc_thresh2
-    value: 512
+    value: 4096
   - name: net.ipv4.neigh.default.gc_thresh3
-    value: 1024
+    value: 8192


### PR DESCRIPTION
Use `sysctl` settings that were removed in MTL-1974, which were employed for all of CSM's lifetime.
