### PR TITLE
CASMTRIAGE-5788 Sysctl role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.15.14] - 2023-08-03
+
+### Added
+
+- CASMTRIAGE-5788
+  -  Use `sysctl` defaults removed by MTL-1974 to [`ansible/roles/csm.ncn.sysctl/vars/main.yml`](ansible/roles/csm.ncn.sysctl/vars/main.yml)
+  - Invoke `csm.ncn.sysctl` in `ncn_nodes.yml` as well as all three playbooks invoked by `site.yml`
+
+### Changed
+
+- Replace all `ansible_os_family` and `ansible_distribution` conditionals for `SLE_HPC` with `ansible_distribution_file_variety == "SUSE"` to be
+  agnostic to the SUSE product line (enabling usage on GCP images in vshastav1 and vshastav-future once we moved to hypervisors)
+
 ## [1.15.13] - 2023-07-05
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Replace all `ansible_os_family` and `ansible_distribution` conditionals for `SLE_HPC` with `ansible_distribution_file_variety == "SUSE"` to be
-  agnostic to the SUSE product line (enabling usage on GCP images in vshastav1 and vshastav-future once we moved to hypervisors)
+  agnostic to the SUSE product line (enabling usage on GCP images in `vshastav1` and `vshastav-future` once we move to hypervisors)
 
 ## [1.15.13] - 2023-07-05
 
@@ -166,7 +166,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ansible playbook for applying csm packages to Compute and Application nodes
 
-[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.15.13...HEAD
+[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.15.14...HEAD
+
+[1.15.14]: https://github.com/Cray-HPE/csm-config/compare/1.15.13...1.15.14
 
 [1.15.13]: https://github.com/Cray-HPE/csm-config/compare/1.15.12...1.15.13
 

--- a/ansible/csm_packages.yml
+++ b/ansible/csm_packages.yml
@@ -40,7 +40,7 @@
     - role: csm.packages
       vars:
         packages: "{{ general_csm_sles_packages }}"
-      when: ansible_distribution == "SLES"
+      when: ansible_distribution_file_variety == "SUSE"
   tasks:
     - name: Add reporters to presets file
       blockinfile:

--- a/ansible/ncn-master_nodes.yml
+++ b/ansible/ncn-master_nodes.yml
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/ansible/ncn-master_nodes.yml
+++ b/ansible/ncn-master_nodes.yml
@@ -41,12 +41,15 @@
     - vars/csm_repos.yml
     - vars/csm_packages.yml
   roles:
+    - role: csm.ncn.sysctl
+      vars:
+        sysctl_set: true
     - role: trust-csm-ssh-keys
     - role: csm.ncn.ca_cert
     - role: csm.packages
       vars:
         packages: "{{ ncn_csm_sles_packages }}"
-      when: ansible_os_family == "SLE_HPC"
+      when: ansible_distribution_file_variety == "SUSE"
     - role: passwordless-ssh
     - role: csm.password
       vars:

--- a/ansible/ncn-storage_nodes.yml
+++ b/ansible/ncn-storage_nodes.yml
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/ansible/ncn-worker_nodes.yml
+++ b/ansible/ncn-worker_nodes.yml
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/ansible/ncn-worker_nodes.yml
+++ b/ansible/ncn-worker_nodes.yml
@@ -41,12 +41,15 @@
     - vars/csm_repos.yml
     - vars/csm_packages.yml
   roles:
+    - role: csm.ncn.sysctl
+      vars:
+        sysctl_set: true
     - role: trust-csm-ssh-keys
     - role: csm.ncn.ca_cert
     - role: csm.packages
       vars:
         packages: "{{ ncn_csm_sles_packages }}"
-      when: ansible_os_family == "SLE_HPC"
+      when: ansible_distribution_file_variety == "SUSE"
     - role: passwordless-ssh
     - role: csm.password
       vars:

--- a/ansible/ncn_nodes.yml
+++ b/ansible/ncn_nodes.yml
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/ansible/ncn_sysctl.yml
+++ b/ansible/ncn_sysctl.yml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/ansible/ncn_sysctl.yml
+++ b/ansible/ncn_sysctl.yml
@@ -1,4 +1,3 @@
-#!/usr/bin/env ansible-playbook
 #
 # MIT License
 #
@@ -21,40 +20,18 @@
 # OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
+#
+---
+dependencies: []
 
-# Deprecation Notice: These top level playbooks are replaced by ncn_nodes.yml
-- hosts: all
-  gather_facts: no
-  tasks:
-    - name: DEPRECATION NOTICE
-      debug:
-        msg: "This playbook is marked for deprecation, please use the unified ncn_nodes.yml playbook instead."
-      run_once: true
-      delegate_to: localhost
-
-# NCN Storage Nodes Play, and NCN Storage Images
-- hosts: Management_Storage
-  gather_facts: yes
-  any_errors_fatal: true
-  remote_user: root
-  vars_files:
-    - vars/csm_repos.yml
-    - vars/csm_packages.yml
-  roles:
-    - role: csm.ncn.sysctl
-      vars:
-        sysctl_set: true
-    - role: trust-csm-ssh-keys
-    - role: csm.ncn.ca_cert
-    - role: csm.packages
-      vars:
-        packages: "{{ ncn_csm_sles_packages }}"
-      when: ansible_distribution_file_variety == "SUSE"
-    - role: passwordless-ssh
-    - role: csm.password
-      vars:
-        password_username: 'root'
-    - role: csm.ssh_keys
-      vars:
-        ssh_keys_username: 'root'
-
+galaxy_info:
+  role_name: csm.password
+  author: randy.kleinman@hpe.com
+  description: Password management for CSM users
+  company: "Hewlett Packard Enterprise Development LP"
+  license: "MIT"
+  min_ansible_version: 2.9
+  platforms: []
+  galaxy_tags:
+    - system
+    - hpc

--- a/ansible/packages.yml
+++ b/ansible/packages.yml
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/ansible/packages.yml
+++ b/ansible/packages.yml
@@ -36,4 +36,4 @@
     - role: csm.packages
       vars:
         packages: "{{ ncn_csm_sles_packages }}"
-      when: ansible_os_family == "SLE_HPC"
+      when: ansible_distribution_file_variety == "SUSE"

--- a/ansible/roles/csm.ncn.ca_cert/tasks/main.yml
+++ b/ansible/roles/csm.ncn.ca_cert/tasks/main.yml
@@ -41,8 +41,7 @@
 - name: Update the certificate
   command: update-ca-certificates
   when: >
-    (ansible_distribution == "SLES" or
-    ansible_distribution == "SLE_HPC") and
+    ansible_distribution_file_variety == "SUSE" and
     ansible_distribution_version == "15.2" and
     cert_file.stat.exists
 
@@ -57,8 +56,7 @@
     - '*.run'
   register: ca_scripts
   when: >
-    (ansible_distribution == "SLES" or
-    ansible_distribution == "SLE_HPC") and
+    ansible_distribution_file_variety == "SUSE" and
     ansible_distribution_version != "15.2" and
     cert_file.stat.exists
 
@@ -67,7 +65,6 @@
   command: "{{ item.path }}"
   loop: "{{ ca_scripts.files }}"
   when: >
-    (ansible_distribution == "SLES" or
-    ansible_distribution == "SLE_HPC") and
+    ansible_distribution_file_variety == "SUSE" and
     ansible_distribution_version != "15.2" and
     cert_file.stat.exists

--- a/ansible/roles/csm.ncn.ca_cert/tasks/main.yml
+++ b/ansible/roles/csm.ncn.ca_cert/tasks/main.yml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019,2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019,2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/ansible/roles/csm.ncn.sysctl/README.md
+++ b/ansible/roles/csm.ncn.sysctl/README.md
@@ -1,0 +1,61 @@
+csm.ncn.sysctl
+=========
+
+Set kernel parameter values with sysctl.
+
+Requirements
+------------
+
+The values must exist in configuration prior to running this role. 
+This role must be run in the context of the CSM Configuration
+Framework Service (CFS) in its Ansible Execution Environment (AEE).
+
+Role Variables
+--------------
+
+Available variables are listed below, along with example values (located in
+`defaults/main.yml` and `vars/main.yml`):
+
+```yaml
+sysctl_config: 'dict'
+```
+
+The dictionary of the sysctl parameters and their values.
+
+```yaml
+sysctl_set: false
+```
+
+Whether to apply this in a running system and reload the values.
+
+Dependencies
+------------
+
+None
+
+Example Playbook
+----------------
+
+This role sets the kernel parameters in `/etc/sysctl.conf`. If `sysctl_set` is `true`, then
+the role also ensures the parameters are written directly to the system with `systctl -w`.
+Note that the playbook will not work with `sysctl_set` set to `true` if the system
+is not running.
+```yaml
+    - hosts: Management
+      roles:
+        - role: csm.ncn.sysctl
+          vars:
+            sysctl_set: false
+            sysctl_config:
+              - name: net.ipv4.conf.all.accept_local
+                value: 1
+```
+License
+-------
+
+MIT
+
+Author Information
+------------------
+
+Copyright 2023 Hewlett Packard Enterprise Development LP

--- a/ansible/roles/csm.ncn.sysctl/defaults/main.yml
+++ b/ansible/roles/csm.ncn.sysctl/defaults/main.yml
@@ -1,8 +1,7 @@
-#!/usr/bin/env ansible-playbook
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -22,34 +21,5 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-# This is a top level play for all NCN nodes that encorporates all 3 kinds of
-# NCN node (management, storage, worker) as well as their Image counterparts.
-# The three seperate top level plays are marked for deprecation via a debug
-# notice.
-- hosts:
-   - Management_Master
-   - Management_Worker
-   - Management_Storage
-  gather_facts: yes
-  any_errors_fatal: true
-  remote_user: root
-  vars_files:
-    - vars/csm_repos.yml
-    - vars/csm_packages.yml
-  roles:
-    - role: csm.ncn.sysctl
-      vars:
-        sysctl_set: true
-    - role: trust-csm-ssh-keys
-    - role: csm.ncn.ca_cert
-    - role: csm.packages
-      vars:
-        packages: "{{ ncn_csm_sles_packages }}"
-      when: ansible_distribution_file_variety == "SUSE"
-    - role: passwordless-ssh
-    - role: csm.password
-      vars:
-        password_username: 'root'
-    - role: csm.ssh_keys
-      vars:
-        ssh_keys_username: 'root'
+# Defaults for the csm.ncn.sysctl role. See the README.md for information.
+sysctl_set: false

--- a/ansible/roles/csm.ncn.sysctl/tasks/main.yml
+++ b/ansible/roles/csm.ncn.sysctl/tasks/main.yml
@@ -1,8 +1,6 @@
-#!/usr/bin/env ansible-playbook
-#
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -22,34 +20,12 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-# This is a top level play for all NCN nodes that encorporates all 3 kinds of
-# NCN node (management, storage, worker) as well as their Image counterparts.
-# The three seperate top level plays are marked for deprecation via a debug
-# notice.
-- hosts:
-   - Management_Master
-   - Management_Worker
-   - Management_Storage
-  gather_facts: yes
-  any_errors_fatal: true
-  remote_user: root
-  vars_files:
-    - vars/csm_repos.yml
-    - vars/csm_packages.yml
-  roles:
-    - role: csm.ncn.sysctl
-      vars:
-        sysctl_set: true
-    - role: trust-csm-ssh-keys
-    - role: csm.ncn.ca_cert
-    - role: csm.packages
-      vars:
-        packages: "{{ ncn_csm_sles_packages }}"
-      when: ansible_distribution_file_variety == "SUSE"
-    - role: passwordless-ssh
-    - role: csm.password
-      vars:
-        password_username: 'root'
-    - role: csm.ssh_keys
-      vars:
-        ssh_keys_username: 'root'
+# Tasks for the csm.ncn.sysctl role
+- name: Set kernel parameters in /etc/sysctl.conf
+  sysctl:
+    name: "{{ item.name }}"
+    value: "{{ item.value }}"
+    state: present
+    reload: "{{ sysctl_set }}"
+    sysctl_set: "{{ sysctl_set }}"
+  loop: "{{ sysctl_config }}"

--- a/ansible/roles/csm.ncn.sysctl/vars/main.yml
+++ b/ansible/roles/csm.ncn.sysctl/vars/main.yml
@@ -1,8 +1,7 @@
-#!/usr/bin/env ansible-playbook
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -22,34 +21,27 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-# This is a top level play for all NCN nodes that encorporates all 3 kinds of
-# NCN node (management, storage, worker) as well as their Image counterparts.
-# The three seperate top level plays are marked for deprecation via a debug
-# notice.
-- hosts:
-   - Management_Master
-   - Management_Worker
-   - Management_Storage
-  gather_facts: yes
-  any_errors_fatal: true
-  remote_user: root
-  vars_files:
-    - vars/csm_repos.yml
-    - vars/csm_packages.yml
-  roles:
-    - role: csm.ncn.sysctl
-      vars:
-        sysctl_set: true
-    - role: trust-csm-ssh-keys
-    - role: csm.ncn.ca_cert
-    - role: csm.packages
-      vars:
-        packages: "{{ ncn_csm_sles_packages }}"
-      when: ansible_distribution_file_variety == "SUSE"
-    - role: passwordless-ssh
-    - role: csm.password
-      vars:
-        password_username: 'root'
-    - role: csm.ssh_keys
-      vars:
-        ssh_keys_username: 'root'
+# Vars for the csm.ncn.sysctl role. See the README.md for information.
+sysctl_config:
+  - name: net.ipv4.conf.all.accept_local
+    value: 0
+  - name: net.ipv4.conf.all.arp_accept
+    value: 0
+  - name: net.ipv4.conf.all.arp_ignore
+    value: 1
+  - name: net.ipv4.conf.all.arp_filter
+    value: 0
+  - name: net.ipv4.conf.all.arp_announce
+    value: 2
+  - name: net.ipv4.conf.all.rp_filter
+    value: 2
+  - name: net.ipv4.neigh.default.gc_interval
+    value: 30
+  - name: net.ipv4.neigh.default.gc_stale_time
+    value: 240
+  - name: net.ipv4.neigh.default.gc_thresh1
+    value: 2048
+  - name: net.ipv4.neigh.default.gc_thresh2
+    value: 4096
+  - name: net.ipv4.neigh.default.gc_thresh3
+    value: 8192


### PR DESCRIPTION
- Backport the `csm.ncn.sysctl` role from 1.5 with CASMTRIAGE-5788's fixes
- Invoke the `csm.ncn.sysctl` role in the `ncn_nodes.yml` book as well as all three playbooks invoked by `site.yml`

Extra:

- Replace all `ansible_os_family` and `ansible_distribution` conditionals for `SLE_HPC` with `ansible_distribution_file_variety == "SUSE"`
