### PR TITLE
CASMTRIAGE-5817: Remove csm-node-identity from package install lists for NCNs and Compute nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.15.15] - 2023-08-08
+
+### Removed
+
+- CASMTRIAGE-5817: Removed `csm-node-identity` from NCN and Compute node package lists in `csm_packages`.
+
 ## [1.15.14] - 2023-08-03
 
 ### Added
@@ -166,7 +172,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ansible playbook for applying csm packages to Compute and Application nodes
 
-[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.15.14...HEAD
+[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.15.15...HEAD
+
+[1.15.15]: https://github.com/Cray-HPE/csm-config/compare/1.15.14...1.15.15
 
 [1.15.14]: https://github.com/Cray-HPE/csm-config/compare/1.15.13...1.15.14
 

--- a/ansible/vars/csm_packages.yml
+++ b/ansible/vars/csm_packages.yml
@@ -29,7 +29,6 @@ ncn_csm_sles_packages:
   - cfs-trust
   - craycli
   - cray-cmstools-crayctldeploy
-  - csm-node-identity
   - csm-testing
   - goss-servers
   - hpe-csm-goss-package
@@ -44,4 +43,3 @@ general_csm_sles_packages:
   - cfs-state-reporter
   - craycli
   - cray-uai-util
-  - csm-node-identity


### PR DESCRIPTION
## Summary and Scope

CFS is failing in some cases, trying to update the `csm-node-identity` RPM from version 1.0.18 to 1.0.20. Prior to a recent change, CFS was not attempting to update this RPM. The root cause of the failure is not related to CFS, but for this support branch, the simplest fix is to just move CFS back to behaving the way it did before (that is, not upgrading that RPM).

This change isn't needed for the develop branch, because current CSM versions will be starting with a version of that RPM that is not susceptible to that problem.

## Issues and Related PRs

* Resolves [CASMTRIAGE-5817](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5817)

## Testing

None yet (although it should happen soon on wasp and surtur). However, the failure is easily reproducible, and this PR removes the package which is causing the failure. And CFS previously didn't include this package. So I am confident the risk here is low.

## Risks and Mitigations

Low risk. See above.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
