### PR TITLE
CASMTRIAGE-5788 Fix YAML Anchor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.16.14] - 2023-08-08
+
+### Changed
+
+- CASMTRIAGE-5788: Prevents YAML interpolation of `hosts: &cfs_image` in `ncn_sysctl.yml`, allowing the playbook to run.
+
 ## [1.16.13] - 2023-08-03
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -280,7 +280,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ansible playbook for applying csm packages to Compute and Application nodes
 
-[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.16.13...HEAD
+[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.16.14...HEAD
+
+[1.16.14]: https://github.com/Cray-HPE/csm-config/compare/1.16.13...1.16.14
 
 [1.16.13]: https://github.com/Cray-HPE/csm-config/compare/1.16.12...1.16.13
 

--- a/ansible/ncn_sysctl.yml
+++ b/ansible/ncn_sysctl.yml
@@ -33,7 +33,7 @@
       vars:
         sysctl_set: true
 
-- hosts: &cfs_image
+- hosts: "Management_Master:Management_Worker:Management_Storage:&cfs_image"
   any_errors_fatal: true
   remote_user: root
   roles:


### PR DESCRIPTION
The `&cfs_image` is breaking the `ncn_sysctl.yml` playbook

```bash
ERROR! Hosts list cannot be empty. Please check your playbook
```

The `&` is causing the YAML to read the value as an anchor, but in this case it is empty. Wrapping it in quotes prevents YAML from interpolating the value.
