### PR TITLE
CASMTRIAGE-5788 Fix `ncn_sysctl.yml`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.15.16] - 2023-08-08
+
+### Changed
+
+- CASMTRIAGE-5788: Fixed `ncn_sysctl.yml` with the correct content from #163 and the fixes from #168
+
 ## [1.15.15] - 2023-08-08
 
 ### Removed

--- a/ansible/ncn_sysctl.yml
+++ b/ansible/ncn_sysctl.yml
@@ -1,7 +1,8 @@
+#!/usr/bin/env ansible-playbook
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -21,17 +22,21 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
----
-dependencies: []
+# This is a top level play for all NCNs that incorporates all 3 kinds of
+# NCN (management, storage, worker) as well as their corresponding images.
+# The play runs csm.ncn.sysctl which sets kernel parameters
+- hosts: "Management_Master:Management_Worker:Management_Storage:!cfs_image"
+  any_errors_fatal: true
+  remote_user: root
+  roles:
+    - role: csm.ncn.sysctl
+      vars:
+        sysctl_set: true
 
-galaxy_info:
-  role_name: csm.password
-  author: randy.kleinman@hpe.com
-  description: Password management for CSM users
-  company: "Hewlett Packard Enterprise Development LP"
-  license: "MIT"
-  min_ansible_version: 2.9
-  platforms: []
-  galaxy_tags:
-    - system
-    - hpc
+- hosts: "Management_Master:Management_Worker:Management_Storage:&cfs_image"
+  any_errors_fatal: true
+  remote_user: root
+  roles:
+    - role: csm.ncn.sysctl
+      vars:
+        sysctl_set: false


### PR DESCRIPTION
Somehow in the `git cherry-pick` the `ncn_sysctl.yml` playbook was set as a totally different file than what went into develop (see #164 and #163).

This corrects the content, as well as incorporating the fix from #168.
