### PR TITLE
CASMCMS-8691: Modify Dockerfile to account for changed RPM locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.16.16] - 2023-08-14
+
+### Changed
+
+= CASMCMS-8691: Update Docker file to account for changed RPM locations
+
+### Changed
+
 ## [1.16.15] - 2023-08-09
 
 ### Changed
@@ -286,7 +294,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ansible playbook for applying csm packages to Compute and Application nodes
 
-[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.16.15...HEAD
+[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.16.16...HEAD
+
+[1.16.16]: https://github.com/Cray-HPE/csm-config/compare/1.16.15...1.16.16
 
 [1.16.15]: https://github.com/Cray-HPE/csm-config/compare/1.16.14...1.16.15
 

--- a/zypper-docker-build.sh
+++ b/zypper-docker-build.sh
@@ -42,13 +42,15 @@ ARTIFACTORY_PASSWORD=$(test -f /run/secrets/ARTIFACTORY_READONLY_TOKEN && cat /r
 CREDS=${ARTIFACTORY_USERNAME:-}
 # Append ":<password>" to credentials variable, if a password is set
 [[ -z ${ARTIFACTORY_PASSWORD} ]] || CREDS="${CREDS}:${ARTIFACTORY_PASSWORD}"
-CSM_REPO_URI="https://${CREDS}@artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp${SP}?auth=basic"
+CSM_SLES_REPO_URI="https://${CREDS}@artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp${SP}?auth=basic"
+CSM_NOOS_REPO_URI="https://${CREDS}@artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos?auth=basic"
 
 zypper --non-interactive rr --all
 zypper --non-interactive clean -a
 zypper --non-interactive ar "${SLES_MIRROR}/Products/SLE-Module-Basesystem/15-SP${SP}/${ARCH}/product/" "sles15sp${SP}-Module-Basesystem-product"
 zypper --non-interactive ar "${SLES_MIRROR}/Updates/SLE-Module-Basesystem/15-SP${SP}/${ARCH}/update/" "sles15sp${SP}-Module-Basesystem-update"
-zypper --non-interactive ar --no-gpgcheck "${CSM_REPO_URI}" csm
+zypper --non-interactive ar --no-gpgcheck "${CSM_SLES_REPO_URI}" csm-sles
+zypper --non-interactive ar --no-gpgcheck "${CSM_NOOS_REPO_URI}" csm-noos
 zypper --non-interactive --gpg-auto-import-keys refresh
 zypper --non-interactive in -f --no-confirm csm-ssh-keys-roles-${CSM_SSH_KEYS_VERSION}
 # Lock the version of csm-ssh-keys-roles, just to be certain it is not upgraded inadvertently somehow later


### PR DESCRIPTION
Fix a build break caused by RPM locations changing to be in the `noos` repository