### PR TITLE
CASMCMS-8691: Modify Dockerfile to account for changed RPM locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.15.17] - 2023-08-14
+
+### Changed
+
+= CASMCMS-8691: Update Docker file to account for changed RPM locations
+
 ## [1.15.16] - 2023-08-08
 
 ### Changed
@@ -178,7 +184,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ansible playbook for applying csm packages to Compute and Application nodes
 
-[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.15.16...HEAD
+[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.15.17...HEAD
+
+[1.15.17]: https://github.com/Cray-HPE/csm-config/compare/1.15.16...1.15.17
 
 [1.15.16]: https://github.com/Cray-HPE/csm-config/compare/1.15.15...1.15.16
 

--- a/zypper-docker-build.sh
+++ b/zypper-docker-build.sh
@@ -42,13 +42,15 @@ ARTIFACTORY_PASSWORD=$(test -f /run/secrets/ARTIFACTORY_READONLY_TOKEN && cat /r
 CREDS=${ARTIFACTORY_USERNAME:-}
 # Append ":<password>" to credentials variable, if a password is set
 [[ -z ${ARTIFACTORY_PASSWORD} ]] || CREDS="${CREDS}:${ARTIFACTORY_PASSWORD}"
-CSM_REPO_URI="https://${CREDS}@artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp${SP}?auth=basic"
+CSM_SLES_REPO_URI="https://${CREDS}@artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp${SP}?auth=basic"
+CSM_NOOS_REPO_URI="https://${CREDS}@artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos?auth=basic"
 
 zypper --non-interactive rr --all
 zypper --non-interactive clean -a
 zypper --non-interactive ar "${SLES_MIRROR}/Products/SLE-Module-Basesystem/15-SP${SP}/${ARCH}/product/" "sles15sp${SP}-Module-Basesystem-product"
 zypper --non-interactive ar "${SLES_MIRROR}/Updates/SLE-Module-Basesystem/15-SP${SP}/${ARCH}/update/" "sles15sp${SP}-Module-Basesystem-update"
-zypper --non-interactive ar --no-gpgcheck "${CSM_REPO_URI}" csm
+zypper --non-interactive ar --no-gpgcheck "${CSM_SLES_REPO_URI}" csm-sles
+zypper --non-interactive ar --no-gpgcheck "${CSM_NOOS_REPO_URI}" csm-noos
 zypper --non-interactive --gpg-auto-import-keys refresh
 zypper --non-interactive in -f --no-confirm csm-ssh-keys-roles-${CSM_SSH_KEYS_VERSION}
 # Lock the version of csm-ssh-keys-roles, just to be certain it is not upgraded inadvertently somehow later


### PR DESCRIPTION
(cherry picked from commit 4a360d125664f7bdc0b781b770f71d01a3c4bd14)

Fix build break caused by RPM locations changing due to `noos` conversion.