### PR TITLE
Update Jenkinsfile to reduce chances of hung or failed builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Disabled concurrent Jenkins builds on same branch/commit
+- Added build timeout to avoid hung builds
+
 ## [1.16.16] - 2023-08-14
 
 ### Changed

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -33,6 +33,8 @@ pipeline {
 
     options {
         buildDiscarder(logRotator(numToKeepStr: "10"))
+        disableConcurrentBuilds()
+        timeout(time: 90, unit: 'MINUTES')
         timestamps()
     }
 


### PR DESCRIPTION
Based on a suggestion made by David, this updates the Jenkinsfile to effect two changes:
- Disable concurrent builds of the same tag or commit
- Add a timeout (90 minutes) as a safeguard against hung builds

These options are used in many other repos in our org to good effect.