### PR TITLE
Change sysctl_set var to be dynamic depending on where it is executed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- CASMTRIAGE-5846: Change `sysctl_set` to be dynamic to prevent failure when building images
-
 ## [1.16.17] - 2023-08-16
 
 ### Changed
 
+- CASMTRIAGE-5846: Change `sysctl_set` to be dynamic to prevent failure when building images
 - Disabled concurrent Jenkins builds on same branch/commit
 - Added build timeout to avoid hung builds
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- CASMTRIAGE-5846: Change `sysctl_set` to be dynamic to prevent failure when building images
+
+## [1.16.17] - 2023-08-16
+
+### Changed
+
 - Disabled concurrent Jenkins builds on same branch/commit
 - Added build timeout to avoid hung builds
 
@@ -299,7 +305,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ansible playbook for applying csm packages to Compute and Application nodes
 
-[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.16.16...HEAD
+[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.16.17...HEAD
+
+[1.16.17]: https://github.com/Cray-HPE/csm-config/compare/1.16.16...1.16.17
 
 [1.16.16]: https://github.com/Cray-HPE/csm-config/compare/1.16.15...1.16.16
 

--- a/ansible/ncn-master_nodes.yml
+++ b/ansible/ncn-master_nodes.yml
@@ -23,6 +23,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 # Deprecation Notice: These top level playbooks are replaced by ncn_nodes.yml
+---
 - hosts: all
   gather_facts: no
   tasks:
@@ -43,7 +44,7 @@
   roles:
     - role: csm.ncn.sysctl
       vars:
-        sysctl_set: true
+        sysctl_set: "{{ false if cray_cfs_image else true|default(false)|bool }}"
     - role: trust-csm-ssh-keys
     - role: csm.ca_cert
     - role: csm.packages

--- a/ansible/ncn-storage_nodes.yml
+++ b/ansible/ncn-storage_nodes.yml
@@ -23,6 +23,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 # Deprecation Notice: These top level playbooks are replaced by ncn_nodes.yml
+---
 - hosts: all
   gather_facts: no
   tasks:
@@ -43,7 +44,7 @@
   roles:
     - role: csm.ncn.sysctl
       vars:
-        sysctl_set: true
+        sysctl_set: "{{ false if cray_cfs_image else true|default(false)|bool }}"
     - role: trust-csm-ssh-keys
     - role: csm.ca_cert
     - role: csm.packages

--- a/ansible/ncn-worker_nodes.yml
+++ b/ansible/ncn-worker_nodes.yml
@@ -23,6 +23,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 # Deprecation Notice: These top level playbooks are replaced by ncn_nodes.yml
+---
 - hosts: all
   gather_facts: no
   tasks:
@@ -43,7 +44,7 @@
   roles:
     - role: csm.ncn.sysctl
       vars:
-        sysctl_set: true
+        sysctl_set: "{{ false if cray_cfs_image else true|default(false)|bool }}"
     - role: trust-csm-ssh-keys
     - role: csm.ca_cert
     - role: csm.packages

--- a/ansible/ncn_nodes.yml
+++ b/ansible/ncn_nodes.yml
@@ -26,6 +26,7 @@
 # NCN (management, storage, worker) as well as their corresponding images.
 # The three seperate top level plays are marked for deprecation via a debug
 # notice.
+---
 - hosts:
    - Management_Master
    - Management_Worker
@@ -36,7 +37,7 @@
   roles:
     - role: csm.ncn.sysctl
       vars:
-        sysctl_set: true
+        sysctl_set: "{{ false if cray_cfs_image else true|default(false)|bool }}"
     - role: trust-csm-ssh-keys
     - role: csm.ca_cert
     - role: passwordless-ssh


### PR DESCRIPTION
@## Summary and Scope

Makes `sysctl_set` dynamic based on whether an image is being built or if it is a running system.

## Issues and Related PRs


* Resolves [CASMTRIAGE-5846](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-5846)

## Testing

Tested on Mug. Used CFS to apply role against `ncn-w002`. Used CFS to build a new image. Reverted code and used CFS to fail building a new image.

### Tested on:

  * Mug


