### PR TITLE
CASMMON-337 Smartmon role should not run during image customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.16.17] - 2023-08-16
 
+### Changed
+
 - CASMTRIAGE-5846: Change `sysctl_set` to be dynamic to prevent failure when building images
 - Disabled concurrent Jenkins builds on same branch/commit
 - Added build timeout to avoid hung builds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-	
 
 ## [1.16.18] - 2023-08-24
 
@@ -304,8 +303,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Convert to gitflo
-## [1.16.17] - 2023-08-16
+- Convert to gitflow/gitversion.
+
+### Added
 
 - Ansible playbook for applying csm packages to Compute and Application nodes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+	
 
-## [1.16.17] - 2023-08-16
+## [1.16.18] - 2023-08-24
 
 ### Changed
+
+- CASMMON-337:Smartmon role should not run during image customization
+- isolate the play to only node personalization is to use hosts: Management_Storage:!cfs_image 
+
+### Changed
+
+## [1.16.17] - 2023-08-16
 
 - CASMTRIAGE-5846: Change `sysctl_set` to be dynamic to prevent failure when building images
 - Disabled concurrent Jenkins builds on same branch/commit
@@ -296,13 +304,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Convert to gitflow/gitversion.
-
-### Added
+- Convert to gitflo
+## [1.16.17] - 2023-08-16
 
 - Ansible playbook for applying csm packages to Compute and Application nodes
 
-[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.16.17...HEAD
+[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.16.18...HEAD
+
+[1.16.18]: https://github.com/Cray-HPE/csm-config/compare/1.16.17...1.16.18
 
 [1.16.17]: https://github.com/Cray-HPE/csm-config/compare/1.16.16...1.16.17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- CASMMON-337:Smartmon role should not run during image customization, only on live storage NCNs.
+- CASMMON-337: Smartmon role should not run during image customization, only on live storage NCNs.
 
 ## [1.16.17] - 2023-08-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- CASMMON-337:Smartmon role should not run during image customization
-- isolate the play to only node personalization is to use hosts: Management_Storage:!cfs_image 
-
-### Changed
+- CASMMON-337:Smartmon role should not run during image customization, only on live storage NCNs.
 
 ## [1.16.17] - 2023-08-16
 

--- a/ansible/ncn-storage_nodes.yml
+++ b/ansible/ncn-storage_nodes.yml
@@ -58,4 +58,12 @@
     - role: csm.ssh_keys
       vars:
         ssh_keys_username: 'root'
+
+# This role runs on all the storage NCNs. It starts the SMART service, and reconfigures and redeploys the running node-exporter
+- hosts:
+   - "Management_Storage:!cfs_image"
+  gather_facts: yes
+  any_errors_fatal: true
+  remote_user: root
+  roles:
     - role: csm.storage.smartmon

--- a/ansible/ncn-storage_nodes.yml
+++ b/ansible/ncn-storage_nodes.yml
@@ -59,7 +59,8 @@
       vars:
         ssh_keys_username: 'root'
 
-# This role runs on all the storage NCNs. It starts the SMART service, and reconfigures and redeploys the running node-exporter
+# This role runs on all the storage NCNs, but not their images.
+# It starts the SMART service, and reconfigures and redeploys the running node-exporter
 - hosts:
    - "Management_Storage:!cfs_image"
   gather_facts: yes

--- a/ansible/ncn_nodes.yml
+++ b/ansible/ncn_nodes.yml
@@ -78,4 +78,13 @@
       vars:
         packages: "{{ common_csm_sles_packages + common_mgmt_ncn_csm_sles_packages + storage_mgmt_ncn_csm_sles_packages }}"
       when: ansible_distribution_file_variety == "SUSE"
+
+# This role runs on all the storage NCNs. It starts the SMART service, and reconfigures and redeploys the running node-exporter
+- hosts:
+   - "Management_Storage:!cfs_image"
+  gather_facts: yes
+  any_errors_fatal: true
+  remote_user: root
+  roles:
     - role: csm.storage.smartmon
+

--- a/ansible/ncn_nodes.yml
+++ b/ansible/ncn_nodes.yml
@@ -79,7 +79,8 @@
         packages: "{{ common_csm_sles_packages + common_mgmt_ncn_csm_sles_packages + storage_mgmt_ncn_csm_sles_packages }}"
       when: ansible_distribution_file_variety == "SUSE"
 
-# This role runs on all the storage NCNs. It starts the SMART service, and reconfigures and redeploys the running node-exporter
+# This role runs on all the storage NCNs, but not their images.
+# It starts the SMART service, and reconfigures and redeploys the running node-exporter
 - hosts:
    - "Management_Storage:!cfs_image"
   gather_facts: yes


### PR DESCRIPTION
Summary and Scope
SuSmartmon role should not run during image customization

Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?

Issues and Related PRs
[List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies.](https://jira-pro.it.hpe.com:8443/browse/CASMMON-337)

Resolves -
https://jira-pro.it.hpe.com:8443/browse/CASMMON-337
Tested on mug

step 1: create json

```bash
 cat ram.json
```
```json
{
  "layers": [
    {
      "name": "configurations-layer-example-1",
      "cloneUrl": "https://api-gw-service-nmn.local/vcs/cray/csm-config-management.git",
      "playbook": "ncn_nodes.yml",
      "branch": "ram"
    }

  ]
}
```

step 2 create session
```bash
cray cfs sessions create --name "ram1" --configuration-name "configurations-example" --ansible-limit "x3000c0s17b0n0"
```
```toml
name = "ram1"

[ansible]
config = "cfs-default-ansible-cfg"
limit = "x3000c0s17b0n0"
verbosity = 0

[configuration]
limit = ""
name = "configurations-example"

[status]
artifacts = []

[tags]

[target]
definition = "dynamic"
groups = []
imageMap = []

[status.session]
startTime = "2023-08-24T10:51:41"
status = "pending"
succeeded = "none"
```
```bash
cray cfs  sessions describe ram1
```
```toml
name = "ram1"

[ansible]
config = "cfs-default-ansible-cfg"
limit = "x3000c0s17b0n0"
verbosity = 0

[configuration]
limit = ""
name = "configurations-example"

[status]
artifacts = []

[tags]

[target]
definition = "dynamic"
groups = []
imageMap = []

[status.session]
job = "cfs-9490c121-0fc2-42c8-a4ac-6a055822a1a3"
startTime = "2023-08-24T10:51:41"
status = "pending"
succeeded = "none"
```
```bash
kubectl logs -n services jobs/cfs-9490c121-0fc2-42c8-a4ac-6a055822a1a3 ansible
```
```text
Inventory generation completed
SSH keys migrated to /root/.ssh
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
HTTP/1.1 200 OK
content-type: text/html; charset=UTF-8
cache-control: no-cache, max-age=0
x-content-type-options: nosniff
date: Thu, 24 Aug 2023 10:51:53 GMT
server: envoy
transfer-encoding: chunked

Sidecar available
Running ncn_nodes.yml from repo https://api-gw-service-nmn.local/vcs/cray/csm-config-management.git

PLAY [Management_Master,Management_Worker,Management_Storage] ******************

TASK [trust-csm-ssh-keys : Inject CSM public Key into SSH authorized_keys file] ***
changed: [x3000c0s17b0n0]

TASK [passwordless-ssh : Write private keyfile to disk with appropriate permissions] ***
changed: [x3000c0s17b0n0]

TASK [passwordless-ssh : Create the CSM public key file on target hosts] *******
changed: [x3000c0s17b0n0]

PLAY [Management_Master,Management_Worker] *************************************
skipping: no hosts matched

PLAY [Management_Storage] ******************************************************

TASK [csm.packages : Allow unsigned repo metadata] *****************************
changed: [x3000c0s17b0n0] => (item={'name': 'csm-sle-15sp2', 'description': 'CSM SLE 15 SP2 Packages (added by Ansible)', 'repo': 'https://packages.local/repository/csm-sle-15sp2'})
changed: [x3000c0s17b0n0] => (item={'name': 'csm-sle-15sp3', 'description': 'CSM SLE 15 SP3 Packages (added by Ansible)', 'repo': 'https://packages.local/repository/csm-sle-15sp3'})
changed: [x3000c0s17b0n0] => (item={'name': 'csm-sle-15sp4', 'description': 'CSM SLE 15 SP4 Packages (added by Ansible)', 'repo': 'https://packages.local/repository/csm-sle-15sp4'})
changed: [x3000c0s17b0n0] => (item={'name': 'csm-noos', 'description': 'CSM No-OS Packages (added by Ansible)', 'repo': 'https://packages.local/repository/csm-noos'})
changed: [x3000c0s17b0n0] => (item={'name': 'csm-embedded', 'description': 'CSM Embedded NCN Packages (added by Ansible)', 'repo': 'https://packages.local/repository/csm-embedded'})

TASK [csm.storage.smartmon : Apply ceph orch] **********************************
changed: [x3000c0s17b0n0] => (item=apply -i /etc/cray/ceph/node-exporter.yml)
changed: [x3000c0s17b0n0] => (item=reconfig node-exporter)
changed: [x3000c0s17b0n0] => (item=redeploy node-exporter)

PLAY RECAP *********************************************************************
x3000c0s17b0n0             : ok=23   changed=5    unreachable=0    failed=0    skipped=5    rescued=0    ignored=0

All playbooks completed successfully
```
