### PR TITLE
Fix build break caused by artifactory authentication changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- CASMCMS-8441: Use csm-rpms/csm-docker mirrors when building image; remove old commented lines from Dockerfile
+
 ## [1.14.2] - 2023-03-01
 ### Changed
 - CASMTRIAGE-5003: Package installation for Compute nodes will only run during image customization
@@ -59,7 +63,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ansible playbook for applying csm packages to Compute and Application nodes
 
-[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.14.0...HEAD
+[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.14.2...HEAD
+
+[1.14.2]: https://github.com/Cray-HPE/csm-config/compare/1.14.1...1.14.2
+
+[1.14.1]: https://github.com/Cray-HPE/csm-config/compare/1.14.0...1.14.1
 
 [1.14.0]: https://github.com/Cray-HPE/csm-config/compare/1.13.0...1.14.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
+= CASMCMS-8691: Update Docker file to account for changed RPM locations
 - CASMCMS-8470: Use artifactory authentication instead of building from unauthenticated artifactory mirrors
 - CASMCMS-8441: Use csm-rpms/csm-docker mirrors when building image; remove old commented lines from Dockerfile
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
+- CASMCMS-8470: Use artifactory authentication instead of building from unauthenticated artifactory mirrors
 - CASMCMS-8441: Use csm-rpms/csm-docker mirrors when building image; remove old commented lines from Dockerfile
 
 ## [1.14.2] - 2023-03-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
-= CASMCMS-8691: Update Docker file to account for changed RPM locations
+- Disabled concurrent Jenkins builds on same branch/commit
+- Added build timeout to avoid hung builds
+- CASMCMS-8691: Update Docker file to account for changed RPM locations
 - CASMCMS-8470: Use artifactory authentication instead of building from unauthenticated artifactory mirrors
 - CASMCMS-8441: Use csm-rpms/csm-docker mirrors when building image; remove old commented lines from Dockerfile
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -36,33 +36,12 @@ RUN \
   zypper --non-interactive rr --all &&\
   zypper --non-interactive ar ${SLES_MIRROR}/Products/SLE-Module-Basesystem/15-SP3/${ARCH}/product/ sles15sp3-Module-Basesystem-product &&\
   zypper --non-interactive ar ${SLES_MIRROR}/Updates/SLE-Module-Basesystem/15-SP3/${ARCH}/update/ sles15sp3-Module-Basesystem-update &&\
-#  zypper --non-interactive ar ${SLES_MIRROR}/Products/SLE-Module-Development-Tools/15-SP3/${ARCH}/product/ sles15sp3-Module-Development-Tools-product &&\
-#  zypper --non-interactive ar ${SLES_MIRROR}/Updates/SLE-Module-Development-Tools/15-SP3/${ARCH}/update/ sles15sp3-Module-Development-Tools-update &&\
-#  zypper --non-interactive ar ${SLES_MIRROR}/Products/SLE-Module-Containers/15-SP3/${ARCH}/product/ sles15sp3-Module-Containers-product &&\
-#  zypper --non-interactive ar ${SLES_MIRROR}/Updates/SLE-Module-Containers/15-SP3/${ARCH}/update/ sles15sp3-Module-Containers-update &&\
-#  zypper --non-interactive ar ${SLES_MIRROR}/Products/SLE-Module-Desktop-Applications/15-SP3/${ARCH}/product/ sles15sp3-Module-Desktop-Applications-product &&\
-#  zypper --non-interactive ar ${SLES_MIRROR}/Updates/SLE-Module-Desktop-Applications/15-SP3/${ARCH}/update/ sles15sp3-Module-Desktop-Applications-update &&\
-#  zypper --non-interactive ar ${SLES_MIRROR}/Products/SLE-Module-HPC/15-SP3/${ARCH}/product/ sles15sp3-Module-HPC-product &&\
-#  zypper --non-interactive ar ${SLES_MIRROR}/Updates/SLE-Module-HPC/15-SP3/${ARCH}/update/ sles15sp3-Module-HPC-update &&\
-#  zypper --non-interactive ar ${SLES_MIRROR}/Products/SLE-Module-Legacy/15-SP3/${ARCH}/product/ sles15sp3-Module-Legacy-product &&\
-#  zypper --non-interactive ar ${SLES_MIRROR}/Updates/SLE-Module-Legacy/15-SP3/${ARCH}/update/ sles15sp3-Module-Legacy-update &&\
-#  zypper --non-interactive ar ${SLES_MIRROR}/Products/SLE-Module-Public-Cloud/15-SP3/${ARCH}/product/ sles15sp3-Module-Public-Cloud-product &&\
-#  zypper --non-interactive ar ${SLES_MIRROR}/Updates/SLE-Module-Public-Cloud/15-SP3/${ARCH}/update/ sles15sp3-Module-Public-Cloud-update &&\
-#  zypper --non-interactive ar ${SLES_MIRROR}/Products/SLE-Module-Python2/15-SP3/${ARCH}/product/ sles15sp3-Module-Python2-product &&\
-#  zypper --non-interactive ar ${SLES_MIRROR}/Updates/SLE-Module-Python2/15-SP3/${ARCH}/update/ sles15sp3-Module-Python2-update &&\
-#  zypper --non-interactive ar ${SLES_MIRROR}/Products/SLE-Module-Server-Applications/15-SP3/${ARCH}/product/ sles15sp3-Module-Server-Applications-product &&\
-#  zypper --non-interactive ar ${SLES_MIRROR}/Updates/SLE-Module-Server-Applications/15-SP3/${ARCH}/update/ sles15sp3-Module-Server-Applications-update &&\
-#  zypper --non-interactive ar ${SLES_MIRROR}/Products/SLE-Module-Web-Scripting/15-SP3/${ARCH}/product/ sles15sp3-Module-Web-Scripting-product &&\
-#  zypper --non-interactive ar ${SLES_MIRROR}/Updates/SLE-Module-Web-Scripting/15-SP3/${ARCH}/update/ sles15sp3-Module-Web-Scripting-update &&\
-#  zypper --non-interactive ar ${SLES_MIRROR}/Products/SLE-Product-SLES/15-SP3/${ARCH}/product/ sles15sp3-Product-SLES-product &&\
-#  zypper --non-interactive ar ${SLES_MIRROR}/Updates/SLE-Product-SLES/15-SP3/${ARCH}/update/ sles15sp3-Product-SLES-update &&\
-#  zypper --non-interactive ar ${SLES_MIRROR}/Updates/SLE-INSTALLER/15-SP3/${ARCH}/update/ sles15sp3-SLE-INSTALLER-update &&\
   zypper --non-interactive clean &&\
   zypper --non-interactive --gpg-auto-import-keys refresh
 
 # Install csm-ssh-keys-roles RPM, and lock the version, just to be certain it is not
 # upgraded inadvertently somehow later
-RUN zypper ar --no-gpgcheck https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp3/ csm && \
+RUN zypper ar --no-gpgcheck https://arti.hpc.amslabs.hpecorp.net/artifactory/csm-rpms-remote/hpe/stable/sle-15sp3/ csm && \
     zypper refresh && \
     zypper in -f --no-confirm csm-ssh-keys-roles-${CSM_SSH_KEYS_VERSION} && \
     zypper al csm-ssh-keys-roles
@@ -71,7 +50,7 @@ RUN zypper ar --no-gpgcheck https://artifactory.algol60.net/artifactory/csm-rpms
 COPY zypper-refresh-patch-clean.sh /
 RUN /zypper-refresh-patch-clean.sh && rm /zypper-refresh-patch-clean.sh
 
-FROM artifactory.algol60.net/csm-docker/stable/cf-gitea-import:@CF_GITEA_IMPORT_VERSION@ as cf-gitea-import-base
+FROM arti.hpc.amslabs.hpecorp.net/csm-docker-remote/stable/cf-gitea-import:@CF_GITEA_IMPORT_VERSION@ as cf-gitea-import-base
 
 # apply security patches to the cf-gitea-import base image
 #  NOTE: do this here in case base image isn't being updated regularly

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,31 +26,23 @@
 FROM artifactory.algol60.net/registry.suse.com/suse/sle15:15.3 as product-content-base
 WORKDIR /
 
+ARG SP=3
+ARG SLES_MIRROR=https://slemaster.us.cray.com/SUSE
+ARG ARCH=x86_64
+
 # Pin the version of csm-ssh-keys being installed. The actual version is substituted by
 # the runBuildPrep script at build time
 ARG CSM_SSH_KEYS_VERSION=@RPM_VERSION@
 
-ARG SLES_MIRROR=https://slemaster.us.cray.com/SUSE
-ARG ARCH=x86_64
-RUN \
-  zypper --non-interactive rr --all &&\
-  zypper --non-interactive ar ${SLES_MIRROR}/Products/SLE-Module-Basesystem/15-SP3/${ARCH}/product/ sles15sp3-Module-Basesystem-product &&\
-  zypper --non-interactive ar ${SLES_MIRROR}/Updates/SLE-Module-Basesystem/15-SP3/${ARCH}/update/ sles15sp3-Module-Basesystem-update &&\
-  zypper --non-interactive clean &&\
-  zypper --non-interactive --gpg-auto-import-keys refresh
-
-# Install csm-ssh-keys-roles RPM, and lock the version, just to be certain it is not
-# upgraded inadvertently somehow later
-RUN zypper ar --no-gpgcheck https://arti.hpc.amslabs.hpecorp.net/artifactory/csm-rpms-remote/hpe/stable/sle-15sp3/ csm && \
-    zypper refresh && \
-    zypper in -f --no-confirm csm-ssh-keys-roles-${CSM_SSH_KEYS_VERSION} && \
-    zypper al csm-ssh-keys-roles
-
-# Apply security patches
+# Do zypper operations using a wrapper script, to isolate the necessary artifactory authentication
+COPY zypper-docker-build.sh /
+# The above script calls the following script, so we need to copy it as well
 COPY zypper-refresh-patch-clean.sh /
-RUN /zypper-refresh-patch-clean.sh && rm /zypper-refresh-patch-clean.sh
+RUN --mount=type=secret,id=ARTIFACTORY_READONLY_USER --mount=type=secret,id=ARTIFACTORY_READONLY_TOKEN \
+    ./zypper-docker-build.sh && \
+    rm /zypper-docker-build.sh /zypper-refresh-patch-clean.sh
 
-FROM arti.hpc.amslabs.hpecorp.net/csm-docker-remote/stable/cf-gitea-import:@CF_GITEA_IMPORT_VERSION@ as cf-gitea-import-base
+FROM artifactory.algol60.net/csm-docker/stable/cf-gitea-import:@CF_GITEA_IMPORT_VERSION@ as cf-gitea-import-base
 
 # apply security patches to the cf-gitea-import base image
 #  NOTE: do this here in case base image isn't being updated regularly
@@ -72,4 +64,3 @@ COPY --chown=nobody:nobody --from=product-content-base /opt/cray/ansible/roles/ 
 COPY --chown=nobody:nobody ansible/ /content/
 
 # Base image entrypoint takes it from here
-

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -33,6 +33,8 @@ pipeline {
 
     options {
         buildDiscarder(logRotator(numToKeepStr: "10"))
+        disableConcurrentBuilds()
+        timeout(time: 90, unit: 'MINUTES')
         timestamps()
     }
 

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/zypper-docker-build.sh
+++ b/zypper-docker-build.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# This script is called during the Docker image build.
+# It isolates the zypper operations, some of which require artifactory authentication,
+# and scrubs the zypper environment after the necessary operations are completed.
+
+# Preconditions:
+# 1. Following variables have been set in the Dockerfile: SP SLES_MIRROR ARCH CSM_SSH_KEYS_VERSION
+# 2. zypper-refresh-patch-clean.sh script has also been copied into the current directory
+
+# Based in part on: https://github.com/Cray-HPE/uai-images/blob/main/uai-images/broker_uai/zypper.sh
+
+set -e +xv
+trap "rm -rf /root/.zypp" EXIT
+
+# Get artifactory credentials and use them to set the csm-rpms stable sles15sp$SP repository URI
+ARTIFACTORY_USERNAME=$(test -f /run/secrets/ARTIFACTORY_READONLY_USER && cat /run/secrets/ARTIFACTORY_READONLY_USER)
+ARTIFACTORY_PASSWORD=$(test -f /run/secrets/ARTIFACTORY_READONLY_TOKEN && cat /run/secrets/ARTIFACTORY_READONLY_TOKEN)
+CREDS=${ARTIFACTORY_USERNAME:-}
+# Append ":<password>" to credentials variable, if a password is set
+[[ -z ${ARTIFACTORY_PASSWORD} ]] || CREDS="${CREDS}:${ARTIFACTORY_PASSWORD}"
+CSM_REPO_URI="https://${CREDS}@artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp${SP}?auth=basic"
+
+zypper --non-interactive rr --all
+zypper --non-interactive clean -a
+zypper --non-interactive ar "${SLES_MIRROR}/Products/SLE-Module-Basesystem/15-SP${SP}/${ARCH}/product/" "sles15sp${SP}-Module-Basesystem-product"
+zypper --non-interactive ar "${SLES_MIRROR}/Updates/SLE-Module-Basesystem/15-SP${SP}/${ARCH}/update/" "sles15sp${SP}-Module-Basesystem-update"
+zypper --non-interactive ar --no-gpgcheck "${CSM_REPO_URI}" csm
+zypper --non-interactive --gpg-auto-import-keys refresh
+zypper --non-interactive in -f --no-confirm csm-ssh-keys-roles-${CSM_SSH_KEYS_VERSION}
+# Lock the version of csm-ssh-keys-roles, just to be certain it is not upgraded inadvertently somehow later
+zypper --non-interactive al csm-ssh-keys-roles
+# Apply security patches (this script also does a zypper clean)
+./zypper-refresh-patch-clean.sh
+# Remove all repos & scrub the zypper directory 
+zypper --non-interactive rr --all
+rm -f /etc/zypp/repos.d/*

--- a/zypper-docker-build.sh
+++ b/zypper-docker-build.sh
@@ -42,13 +42,15 @@ ARTIFACTORY_PASSWORD=$(test -f /run/secrets/ARTIFACTORY_READONLY_TOKEN && cat /r
 CREDS=${ARTIFACTORY_USERNAME:-}
 # Append ":<password>" to credentials variable, if a password is set
 [[ -z ${ARTIFACTORY_PASSWORD} ]] || CREDS="${CREDS}:${ARTIFACTORY_PASSWORD}"
-CSM_REPO_URI="https://${CREDS}@artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp${SP}?auth=basic"
+CSM_SLES_REPO_URI="https://${CREDS}@artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp${SP}?auth=basic"
+CSM_NOOS_REPO_URI="https://${CREDS}@artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/noos?auth=basic"
 
 zypper --non-interactive rr --all
 zypper --non-interactive clean -a
 zypper --non-interactive ar "${SLES_MIRROR}/Products/SLE-Module-Basesystem/15-SP${SP}/${ARCH}/product/" "sles15sp${SP}-Module-Basesystem-product"
 zypper --non-interactive ar "${SLES_MIRROR}/Updates/SLE-Module-Basesystem/15-SP${SP}/${ARCH}/update/" "sles15sp${SP}-Module-Basesystem-update"
-zypper --non-interactive ar --no-gpgcheck "${CSM_REPO_URI}" csm
+zypper --non-interactive ar --no-gpgcheck "${CSM_SLES_REPO_URI}" csm-sles
+zypper --non-interactive ar --no-gpgcheck "${CSM_NOOS_REPO_URI}" csm-noos
 zypper --non-interactive --gpg-auto-import-keys refresh
 zypper --non-interactive in -f --no-confirm csm-ssh-keys-roles-${CSM_SSH_KEYS_VERSION}
 # Lock the version of csm-ssh-keys-roles, just to be certain it is not upgraded inadvertently somehow later


### PR DESCRIPTION
This PR just backports several commits from the master branch that updated the Dockerfile (and associated scripts) to handle changes in the artifactory authentication and some changed RPM locations.