### PR TITLE
CASMINST-6624: Provide RPMs needed for enabling SMART data on UAN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## Unreleased
+
+## [1.14.3] - 2023-09-08
 ### Changed
+- CASMINST-6624: Provide RPMs needed for enabling SMART data on UAN
 - Disabled concurrent Jenkins builds on same branch/commit
 - Added build timeout to avoid hung builds
 - CASMCMS-8691: Update Docker file to account for changed RPM locations
@@ -67,7 +70,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ansible playbook for applying csm packages to Compute and Application nodes
 
-[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.14.2...HEAD
+[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.14.3...HEAD
+
+[1.14.3]: https://github.com/Cray-HPE/csm-config/compare/1.14.2...1.14.3
 
 [1.14.2]: https://github.com/Cray-HPE/csm-config/compare/1.14.1...1.14.2
 

--- a/ansible/csm_packages.yml
+++ b/ansible/csm_packages.yml
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -48,3 +48,31 @@
           # More Cray services
           enable bos-reporter.service
           enable cfs-state-reporter.service
+
+# Application Nodes Play  
+- hosts: Application:!cray_cfs_image
+  gather_facts: yes
+  any_errors_fatal: true
+  remote_user: root
+  vars_files:
+    - vars/csm_repos.yml
+    - vars/csm_packages.yml
+
+  roles:
+    # Install CSM repositories and packages
+    - role: csm.packages
+      vars:
+        packages: "{{ application_csm_sles_packages }}"
+      when:
+        - ansible_distribution == "SLES"
+  tasks:
+    - name: Enable smart service
+      systemd:
+        name: smart
+        state: started
+        enabled: true
+    - name: Enable cray-node-exporter service
+      systemd:
+        name: cray-node-exporter
+        state: started
+        enabled: true

--- a/ansible/vars/csm_packages.yml
+++ b/ansible/vars/csm_packages.yml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -28,3 +28,9 @@ ncn_csm_sles_packages:
 general_csm_sles_packages:
   - bos-reporter
   - cfs-state-reporter
+
+# All Application nodes
+application_csm_sles_packages:
+  - cray-node-exporter
+  - smart-mon
+  - smartmontools

--- a/ansible/vars/csm_packages.yml
+++ b/ansible/vars/csm_packages.yml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves  - https://jira-pro.it.hpe.com:8443/browse/CASMMON-339


## Testing

_List the environments in which these changes were tested._

### Tested on:
Shandy & Tyr

### Test logs:
```text
PLAY [Application] *************************************************************

TASK [csm.gpg_keys : Fetch the HPE GPG Signing Key from the K8S secret] ********
ok: [x3000c0s23b0n0]

TASK [csm.gpg_keys : Create a temporary file to store the key content] *********
changed: [x3000c0s23b0n0]

TASK [csm.gpg_keys : Copy the key content to a temporary file] *****************
changed: [x3000c0s23b0n0]

TASK [csm.gpg_keys : Install the HPE Signing Key] ******************************
ok: [x3000c0s23b0n0]

TASK [csm.packages : Configure CSM RPM Repos (SLES-based)] *********************
ok: [x3000c0s23b0n0] => (item={'name': 'csm-sle-15sp2', 'description': 'CSM SLE 15 SP2 Packages (added by Ansible)', 'repo': 'https://packages.local/repository/csm-sle-15sp2'})
ok: [x3000c0s23b0n0] => (item={'name': 'csm-sle-15sp3', 'description': 'CSM SLE 15 SP3 Packages (added by Ansible)', 'repo': 'https://packages.local/repository/csm-sle-15sp3'})
ok: [x3000c0s23b0n0] => (item={'name': 'csm-sle-15sp4', 'description': 'CSM SLE 15 SP4 Packages (added by Ansible)', 'repo': 'https://packages.local/repository/csm-sle-15sp4'})

TASK [csm.packages : Allow unsigned repo metadata] *****************************
changed: [x3000c0s23b0n0] => (item={'name': 'csm-sle-15sp2', 'description': 'CSM SLE 15 SP2 Packages (added by Ansible)', 'repo': 'https://packages.local/repository/csm-sle-15sp2'})
changed: [x3000c0s23b0n0] => (item={'name': 'csm-sle-15sp3', 'description': 'CSM SLE 15 SP3 Packages (added by Ansible)', 'repo': 'https://packages.local/repository/csm-sle-15sp3'})
changed: [x3000c0s23b0n0] => (item={'name': 'csm-sle-15sp4', 'description': 'CSM SLE 15 SP4 Packages (added by Ansible)', 'repo': 'https://packages.local/repository/csm-sle-15sp4'})

TASK [csm.packages : Install RPMs (SLES-based)] ********************************
changed: [x3000c0s23b0n0]

TASK [Enable smart service] ****************************************************
changed: [x3000c0s23b0n0]

TASK [Enable cray-node-exporter service] ***************************************
changed: [x3000c0s23b0n0]

PLAY RECAP *********************************************************************
x3000c0s23b0n0             : ok=11   changed=6    unreachable=0    failed=0    skipped=7    rescued=0    ignored=0

All playbooks completed successfully
```

```text
uan01:/etc/cray # systemctl status smart
● smart.service - SMART
     Loaded: loaded (/usr/lib/systemd/system/smart.service; enabled; vendor preset: disabled)
     Active: activating (auto-restart) since Thu 2023-09-07 01:48:52 CDT; 22s ago
   Main PID: 30649 (code=exited, status=0/SUCCESS)
uan01:/etc/cray # systemctl status cray-node-exporter
● cray-node-exporter.service - Node Exporter
     Loaded: loaded (/etc/systemd/system/cray-node-exporter.service; enabled; vendor preset: disabled)
     Active: active (running) since Thu 2023-09-07 01:48:53 CDT; 33s ago
   Main PID: 31287 (node_exporter)
      Tasks: 4
     CGroup: /system.slice/cray-node-exporter.service
             └─31287 /usr/bin/node_exporter --web.listen-address=10.252.1.23:9100 --web.disable-exporter-metrics --collector.disable-defau>

Sep 07 01:48:53 uan01 systemd[1]: Started Node Exporter.
Sep 07 01:48:53 uan01 cray-node-exporter[31287]: ts=2023-09-07T06:48:53.424Z caller=node_exporter.go:180 level=info msg="Starting node_exp>
Sep 07 01:48:53 uan01 cray-node-exporter[31287]: ts=2023-09-07T06:48:53.424Z caller=node_exporter.go:181 level=info msg="Build context" bu>
Sep 07 01:48:53 uan01 cray-node-exporter[31287]: ts=2023-09-07T06:48:53.424Z caller=node_exporter.go:183 level=warn msg="Node Exporter is >
Sep 07 01:48:53 uan01 cray-node-exporter[31287]: ts=2023-09-07T06:48:53.424Z caller=node_exporter.go:110 level=info msg="Enabled collector>
Sep 07 01:48:53 uan01 cray-node-exporter[31287]: ts=2023-09-07T06:48:53.424Z caller=node_exporter.go:117 level=info collector=textfile
Sep 07 01:48:53 uan01 cray-node-exporter[31287]: ts=2023-09-07T06:48:53.424Z caller=tls_config.go:232 level=info msg="Listening on" addres>
Sep 07 01:48:53 uan01 cray-node-exporter[31287]: ts=2023-09-07T06:48:53.424Z caller=tls_config.go:235 level=info msg="TLS is disabled." ht>
lines 1-16/16 (END)
```

```text
uan01:/etc/cray # zypper search -i smart
Loading repository data...
Reading installed packages...

S  | Name          | Summary                               | Type
---+---------------+---------------------------------------+--------
i  | libsmartcols1 | Column-based text sort engine         | package
i+ | smart-mon     | Install and configuration of smartmon | package
i+ | smartmontools | Monitor for SMART devices             | package
```

```text
uan01:/etc/cray # curl 10.252.1.23:9100/metrics
#HELP node_exporter_build_info A metric with a constant '1' value labeled by version, revision, branch, and goversion from which node_exporter was built.
#TYPE node_exporter_build_info gauge
node_exporter_build_info{branch="HEAD",goversion="go1.19.3",revision="1b48970ffcf5630534fb00bb0687d73c66d1c959",version="1.5.0"} 1
#HELP node_scrape_collector_duration_seconds node_exporter: Duration of a collector scrape.
#TYPE node_scrape_collector_duration_seconds gauge
node_scrape_collector_duration_seconds{collector="textfile"} 0.001153622
#HELP node_scrape_collector_success node_exporter: Whether a collector succeeded.
#TYPE node_scrape_collector_success gauge
node_scrape_collector_success{collector="textfile"} 1
#HELP node_textfile_mtime_seconds Unixtime mtime of textfiles successfully read.
#TYPE node_textfile_mtime_seconds gauge
node_textfile_mtime_seconds{file="/var/lib/node_exporter/smartmon.prom"} 1.694069332e+09
#HELP node_textfile_scrape_error 1 if there was an error opening or reading a file, 0 otherwise
#TYPE node_textfile_scrape_error gauge
node_textfile_scrape_error 0
#HELP promhttp_metric_handler_errors_total Total number of internal errors encountered by the promhttp metric handler.
#TYPE promhttp_metric_handler_errors_total counter
promhttp_metric_handler_errors_total{cause="encoding"} 0
promhttp_metric_handler_errors_total{cause="gathering"} 0
```  
