### PR TITLE
CASMCMS-8696: Kata installation Ansible play

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.16.21] - 2023-09-22
+
+### Changed
+
+- CASMCMS-8696: Create an Ansible play that configures a compute image for IMS builds.
+
 ## [1.16.20] - 2023-09-21
 
 ### Added
@@ -27,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CASMINST-6624: Provide RPMs needed for enabling SMART data on UAN
 
 ### Dependencies
+
 - Bump `actions/checkout` from 3 to 4 ([#187](https://github.com/Cray-HPE/csm-config/pull/187))
 
 ## [1.16.18] - 2023-08-24
@@ -330,7 +337,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ansible playbook for applying csm packages to Compute and Application nodes
 
-[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.16.20...HEAD
+[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.16.21...HEAD
+
+[1.16.21]: https://github.com/Cray-HPE/csm-config/compare/1.16.20...1.16.21
 
 [1.16.20]: https://github.com/Cray-HPE/csm-config/compare/1.16.19...1.16.20
 

--- a/ansible/ims_computes.yml
+++ b/ansible/ims_computes.yml
@@ -1,0 +1,41 @@
+#!/usr/bin/env ansible-playbook
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+- hosts: Application:Compute:&cfs_image
+  gather_subset:
+    - '!all'
+    - '!min'
+    - distribution
+  any_errors_fatal: true
+  remote_user: root
+  vars_files:
+    - vars/csm_ims_repos.yml
+    - vars/csm_packages.yyml
+  roles:
+    - role: csm.packages
+      vars: 
+        packages: "{{ ims_compute_sles_packages }}"
+    - role: csm.ims-remote
+      vars:
+        builder_architecture: "{{ ansible_env.IMS_ARCH |default('x86_64') }}"

--- a/ansible/roles/csm.ims-remote/README.md
+++ b/ansible/roles/csm.ims-remote/README.md
@@ -1,0 +1,59 @@
+csm.ims-remote
+==================
+
+Configure a compute image to be able to build IMS images
+
+Requirements
+------------
+
+The system is able to access the `ims-remote-third-party` repo in Nexus.
+
+Role Variables
+--------------
+
+Available variables are listed below, along with default values (located in
+`defaults/main.yml`):
+
+```yaml
+    builder_architecture: x86_64
+```
+
+The architecture of the compute node to be customized. 
+
+```yaml
+    kata_version: 2.5.1
+```
+
+The version of Kata to be downloaded.
+
+Dependencies
+------------
+
+None.
+
+Example Playbook
+----------------
+
+```yaml
+   - hosts: Application:Compute
+     gather_subset:
+       - '!all'
+       - '!min'
+       - distribution
+    any_errors_fatal: true
+    remote_user: root
+    roles:
+      - role: csm.ims-remote
+        vars:
+          builder_architecture: "{{ ansible_env.IMS_ARCH |default('x86_64') }}"
+```
+
+License
+-------
+
+MIT
+
+Author Information
+------------------
+
+Copyright 2023 Hewlett Packard Enterprise Development LP

--- a/ansible/roles/csm.ims-remote/defaults/main.yml
+++ b/ansible/roles/csm.ims-remote/defaults/main.yml
@@ -25,10 +25,4 @@
 
 builder_architecture: "x86_64"
 kata_version: "2.5.1"
-ims_remote_packages:
-  - podman
-  - containerd
-  - containerd.ctr
-  - cni
-  - cni.plugins
-  - podman-cni-config
+

--- a/ansible/roles/csm.ims-remote/defaults/main.yml
+++ b/ansible/roles/csm.ims-remote/defaults/main.yml
@@ -1,0 +1,34 @@
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# Defaults for the csm.ims-remote role. See the README.md for information.
+
+builder_architecture: "x86_64"
+kata_version: "2.5.1"
+ims_remote_packages:
+  - podman
+  - containerd
+  - containerd.ctr
+  - cni
+  - cni.plugins
+  - podman-cni-config

--- a/ansible/roles/csm.ims-remote/tasks/main.yml
+++ b/ansible/roles/csm.ims-remote/tasks/main.yml
@@ -1,0 +1,69 @@
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# Tasks for the csm.ims-remote role
+---
+
+- name: Download Kata Containers
+  delegate_to: localhost
+  run_once: true
+  get_url:
+    url: "https://packages.local/repository/ims-remote-third-party/kata/kata-static-{{ kata_version }}-{{ builder_architecture }}.tar.xz"
+    dest: /tmp
+    validate_certs: no
+  register: source_file
+
+- name: Extract
+  unarchive:
+    list_files: true
+    src: "/tmp/kata-static-{{ kata_version }}-{{ builder_architecture }}.tar.xz"
+    dest: /opt
+
+- name: Copy Kata to Canonical Location
+  copy:
+    src: /opt/opt/kata
+    dest: /opt
+    remote_src: true
+
+- name: Apply Execute Permissions
+  file:
+    mode: u+rwx
+    recurse: true
+    state: directory
+    path: /opt/kata/bin/
+
+- name: Setup Symlink
+  command: ln -sf /opt/kata/bin/containerd-shim-kata-v2 /usr/local/bin/containerd-shim-kata-qemu-v2
+
+- name: Configure Kata hypervisor rfile
+  command: sed -i 's/\[\"enable_iommu\"\]/["enable_iommu", "virtio_fs_extra_args", "default_memory", "kernel_params", "cpu_features"]/' /opt/kata/share/defaults/kata-containers/configuration-qemu.toml
+
+- name: Delete Redundant Dir
+  file:
+    path: /opt/opt
+    state: absent
+
+- name: Delete kata tarball
+  file:
+    path: "/tmp/kata-static-{{ kata_version }}-{{ builder_architecture }}.tar.xz"
+    state: absent

--- a/ansible/vars/csm_ims_repos.yml
+++ b/ansible/vars/csm_ims_repos.yml
@@ -1,0 +1,31 @@
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+csm_sles_repositories:
+- name: SUSE-SLE-Module-Containers-15-sp5-x86_64-Pool
+  description: "SUSE Container Modules (added by Ansible)"
+  repo: https://packages.local/repository/SUSE-SLE-Module-Containers-15-sp5-x86_64-Pool
+- name: SUSE-SLE-Module-Basesystem-15-sp5-x86_64-Pool
+  description: "SUSE Basesystem Modules (added by Ansible)"
+  repo: https://packages.local/repository/SUSE-SLE-Module-Basesystem-15-sp5-x86_64-Pool

--- a/ansible/vars/csm_packages.yml
+++ b/ansible/vars/csm_packages.yml
@@ -72,3 +72,7 @@ compute_csm_sles_packages:
   - acpid
   - bos-reporter
   - cray-uai-util
+
+# IMS Remote Compute Nodes:
+ims_compute_sles_packages:
+  - podman


### PR DESCRIPTION
## Summary and Scope

Ansible play to customize an image with kata containers and install necessary packages to facilitate remote ims image building.

## Issues and Related PRs


* Resolves [CASMCMS-8696](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8696)

## Testing

### Tested on:
Tested on mug.

### Test description:

Ran customizations on metal image on mug environment.

## Risks and Mitigations

No

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

