### PR TITLE
CASMINST-6624: Provide RPMs needed for enabling SMART data on UAN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.15.21] - 2023-09-21
+
+### Changed
+
+- CASMINST-6624: Provide RPMs needed for enabling SMART data on UAN.
+
 ## [1.15.20] - 2023-09-14
 
 ### Changed
@@ -204,7 +210,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ansible playbook for applying csm packages to Compute and Application nodes
 
-[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.15.18...HEAD
+[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.15.21...HEAD
+
+[1.15.21]: https://github.com/Cray-HPE/csm-config/compare/1.15.20...1.15.21
+
+[1.15.20]: https://github.com/Cray-HPE/csm-config/compare/1.15.19...1.15.20
+
+[1.15.19]: https://github.com/Cray-HPE/csm-config/compare/1.15.18...1.15.19
 
 [1.15.18]: https://github.com/Cray-HPE/csm-config/compare/1.15.17...1.15.18
 

--- a/ansible/csm_packages.yml
+++ b/ansible/csm_packages.yml
@@ -49,3 +49,34 @@
           # More Cray services
           enable bos-reporter.service
           enable cfs-state-reporter.service
+
+# Application-nodes only play
+- hosts: Application:!cfs_image
+  gather_facts: yes
+  # Gather the minimum that gets the ansible_distribution variable set
+  gather_subset:
+    - '!all'
+    - '!min'
+    - distribution
+  any_errors_fatal: true
+  remote_user: root
+  vars_files:
+    - vars/csm_repos.yml
+    - vars/csm_packages.yml
+  roles:
+    # Install CSM repositories and packages
+    - role: csm.packages
+      vars:
+        packages: "{{ application_csm_sles_packages }}"
+      when: ansible_distribution_file_variety == "SUSE"
+  tasks:
+    - name: Enable smart service
+      systemd:
+        name: smart
+        state: started
+        enabled: true
+    - name: Enable cray-node-exporter service
+      systemd:
+        name: cray-node-exporter
+        state: started
+        enabled: true

--- a/ansible/vars/csm_packages.yml
+++ b/ansible/vars/csm_packages.yml
@@ -43,3 +43,9 @@ general_csm_sles_packages:
   - cfs-state-reporter
   - craycli
   - cray-uai-util
+
+# All Application nodes
+application_csm_sles_packages:
+  - cray-node-exporter
+  - smart-mon
+  - smartmontools


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves- https://jira-pro.it.hpe.com:8443/browse/CASMINST-6624

## Testing

_List the environments in which these changes were tested._

### Tested on:
Shandy & Tyr

### Test logs:

TASK [csm.packages : Configure CSM RPM Repos (SLES-based)] *********************
changed: [x3000c0s20b0n0] => (item={'name': 'csm-sle', 'description': 'CSM SLE Packages (added by Ansible)', 'repo': '[https://packages.local/repository/csm-sle-${releasever_major}sp${releasever_minor}](https://packages.local/repository/csm-sle-$%7breleasever_major%7dsp$%7breleasever_minor%7d)'})

TASK [csm.packages : Allow unsigned repo metadata] *****************************
changed: [x3000c0s20b0n0] => (item={'name': 'csm-sle', 'description': 'CSM SLE Packages (added by Ansible)', 'repo': '[https://packages.local/repository/csm-sle-${releasever_major}sp${releasever_minor}](https://packages.local/repository/csm-sle-$%7breleasever_major%7dsp$%7breleasever_minor%7d)'})
changed: [x3000c0s20b0n0] => (item={'name': 'csm-noos', 'description': 'CSM No-OS Packages (added by Ansible)', 'repo': 'https://packages.local/repository/csm-noos'})
changed: [x3000c0s20b0n0] => (item={'name': 'csm-embedded', 'description': 'CSM Embedded NCN Packages (added by Ansible)', 'repo': 'https://packages.local/repository/csm-embedded'})

TASK [Enable smart service] ****************************************************
changed: [x3000c0s20b0n0]

TASK [Enable cray-node-exporter service] ***************************************
changed: [x3000c0s20b0n0]

PLAY RECAP *********************************************************************
x3000c0s20b0n0             : ok=6    changed=4    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0

All playbooks completed successfully


uan01:/etc/systemd # curl 10.252.1.16:9100/metrics
#HELP node_exporter_build_info A metric with a constant '1' value labeled by version, revision, branch, and goversion from which node_exporter was built.
#TYPE node_exporter_build_info gauge
node_exporter_build_info{branch="HEAD",goversion="go1.19.3",revision="1b48970ffcf5630534fb00bb0687d73c66d1c959",version="1.5.0"} 1
#HELP node_scrape_collector_duration_seconds node_exporter: Duration of a collector scrape.
#TYPE node_scrape_collector_duration_seconds gauge
node_scrape_collector_duration_seconds{collector="textfile"} 0.000240956
#HELP node_scrape_collector_success node_exporter: Whether a collector succeeded.
#TYPE node_scrape_collector_success gauge
node_scrape_collector_success{collector="textfile"} 1
#HELP node_textfile_mtime_seconds Unixtime mtime of textfiles successfully read.
#TYPE node_textfile_mtime_seconds gauge
node_textfile_mtime_seconds{file="/var/lib/node_exporter/smartmon.prom"} 1.694340449e+09
#HELP node_textfile_scrape_error 1 if there was an error opening or reading a file, 0 otherwise
#TYPE node_textfile_scrape_error gauge
node_textfile_scrape_error 0
#HELP promhttp_metric_handler_errors_total Total number of internal errors encountered by the promhttp metric handler.
#TYPE promhttp_metric_handler_errors_total counter
promhttp_metric_handler_errors_total{cause="encoding"} 0
promhttp_metric_handler_errors_total{cause="gathering"} 0
#HELP smartmon_device_active SMART metric device_active
#TYPE smartmon_device_active gauge
smartmon_device_active{disk="/dev/sda",type="scsi"} 1