### PR TITLE
CASMINST-6661: Install UAI entrypoint package to compute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- CASMINST-6667: Include cray-uai-util package in compute nodes
+
 ## [1.16.19] - 2023-09-12
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- CASMINST-6667: Include cray-uai-util package in compute nodes
+### Added
+
+- CASMINST-6667: Include `cray-uai-util` package in compute nodes
 
 ## [1.16.19] - 2023-09-12
 

--- a/ansible/vars/csm_packages.yml
+++ b/ansible/vars/csm_packages.yml
@@ -71,3 +71,4 @@ application_csm_sles_packages:
 compute_csm_sles_packages:
   - acpid
   - bos-reporter
+  - cray-uai-util


### PR DESCRIPTION
## Summary and Scope

Install `cray-uai-util` to both compute and application images.

## Issues and Related PRs

* Resolves [CASMINST-6661](https://jira-pro.it.hpe.com:8443/browse/CASMINST-6661)

## Testing

* `beau`
* Virtual Shasta

### Test description:

Built an image on vshasta and verified the package was installed.

<img width="1624" alt="Screenshot 2023-09-20 at 4 29 11 PM" src="https://github.com/Cray-HPE/csm-config/assets/81820210/815d361c-0fe6-4550-996f-44535f9007ab">

```
compute:~ # rpm -qa | grep uai
cray-uai-util-2.2.1-1.noarch
```

## Risks and Mitigations

Low risk

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

