### PR TITLE
CASMINST-6662: Enable csm-node-heartbeat/csm-node-identity on managed nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.16.20] - 2023-09-21
+
 ### Added
 
 - CASMINST-6667: Include `cray-uai-util` package in compute nodes
+- CASMINST-6662: Enable `csm-node-heartbeat` and `csm-node-identity` services on compute and
+  application nodes in `csm_packages.yml`.
+
+### Changed
+
+- CASMINST-6662: Ensure that `systemd` preset changes are applied after preset file is updated
+  in `csm_packages.yml`.
 
 ## [1.16.19] - 2023-09-12
 
@@ -321,7 +330,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ansible playbook for applying csm packages to Compute and Application nodes
 
-[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.16.19...HEAD
+[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.16.20...HEAD
+
+[1.16.20]: https://github.com/Cray-HPE/csm-config/compare/1.16.19...1.16.20
 
 [1.16.19]: https://github.com/Cray-HPE/csm-config/compare/1.16.18...1.16.19
 

--- a/ansible/csm_packages.yml
+++ b/ansible/csm_packages.yml
@@ -35,6 +35,12 @@
   vars_files:
     - vars/csm_repos.yml
     - vars/csm_packages.yml
+  vars:
+    csm_services:
+      - bos-reporter
+      - cfs-state-reporter
+      - csm-node-heartbeat
+      - csm-node-identity
   roles:
     # Install CSM repositories and packages
     - role: csm.packages
@@ -42,13 +48,16 @@
         packages: "{{ common_csm_sles_packages + application_csm_sles_packages }}"
       when: ansible_distribution_file_variety == "SUSE"
   tasks:
-    - name: Add reporters to presets file
-      blockinfile:
+    - name: Add CSM services to presets file
+      loop: "{{ csm_services }}"
+      lineinfile:
         path: "/usr/lib/systemd/system-preset/89-cray-default.preset"
-        block: |
-          # More Cray services
-          enable bos-reporter.service
-          enable cfs-state-reporter.service
+        create: true
+        state: present
+        line: "enable {{item}}.service"
+    - name: Apply presets for CSM services
+      loop: "{{ csm_services }}"
+      command: systemctl preset "{{item}}.service"
 
 # Compute-nodes only play
 - hosts: Compute:&cfs_image
@@ -60,6 +69,12 @@
     - distribution
   any_errors_fatal: true
   remote_user: root
+  vars:
+    csm_services:
+      - bos-reporter
+      - cfs-state-reporter
+      - csm-node-heartbeat
+      - csm-node-identity
   vars_files:
     - vars/csm_repos.yml
     - vars/csm_packages.yml
@@ -70,15 +85,18 @@
         packages: "{{ common_csm_sles_packages + compute_csm_sles_packages }}"
       when: ansible_distribution_file_variety == "SUSE"
   tasks:
-    - name: Add reporters to presets file
-      blockinfile:
+    - name: Add CSM services to presets file
+      loop: "{{ csm_services }}"
+      lineinfile:
         path: "/usr/lib/systemd/system-preset/89-cray-default.preset"
-        block: |
-          # More Cray services
-          enable bos-reporter.service
-          enable cfs-state-reporter.service
+        create: true
+        state: present
+        line: "enable {{item}}.service"
+    - name: Apply presets for CSM services
+      loop: "{{ csm_services }}"
+      command: systemctl preset "{{item}}.service"
 
-# Application-nodes only play
+# Application-nodes only play, excluding images
 - hosts: Application:!cfs_image
   gather_facts: yes
   # Gather the minimum that gets the ansible_distribution variable set


### PR DESCRIPTION
## Summary and Scope

The csm-node-identity and csm-node-heartbeat services recently changed names and are now owned by CSM. On managed nodes, these services are not being enabled. This PR updates the relevant CSM play to add these services to the list of CSM services that we enable on managed nodes.

This PR also changes how the `systemd` presets file is handled. First, instead of handling it with a large block of text, the line for each service is handled individually. Second, after the file is updated, `systemctl preset <whatever>.service` is invoked to apply the preset. This addresses the problem introduced by editing the presets file after the package has already been installed.

## Issues and Related PRs

Resolves [CASMINST-6662](https://jira-pro.it.hpe.com:8443/browse/CASMINST-6662)

## Testing

I did some preliminary test of this on tyr, where the problem was reported.

Peter Hill (who reported the problem) recreated the compute images on tyr with this fix in place and verified that the problem he found related to this no longer occurs.

## Risks and Mitigations

Without this, managed nodes are sad.
