### PR TITLE
MTL-2281: don't use FQCNs; older CSM ansible versions have bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.15.22] - 2023-09-22
+
+### Changed
+
+- MTL-2281: don't use FQCNs; older CSM ansible versions have bugs
+
 ## [1.15.21] - 2023-09-21
 
 ### Changed

--- a/ansible/roles/csm.ncn.cve_mitigations/tasks/main.yml
+++ b/ansible/roles/csm.ncn.cve_mitigations/tasks/main.yml
@@ -23,26 +23,27 @@
 #
 ---
 - name: Count AMD CPUs
-  ansible.builtin.shell: grep -c "^model name.*AMD EPYC 7..2" /proc/cpuinfo
+  shell: grep -c "^model name.*AMD EPYC 7..2" /proc/cpuinfo
   args:
     executable: /bin/bash
   register: matching_cpus
+  ignore_errors: true
   changed_when: false
 
 - name: Install msr-tools
-  community.general.zypper:
+  zypper:
     name: msr-tools
     state: present
   when: matching_cpus.stdout|int > 0
 
 - name: Load msr kernel module
-  community.general.modprobe:
+  modprobe:
     name: msr
     state: present
   when: matching_cpus.stdout|int > 0
 
 - name: Apply Zenbleed mitigation
-  ansible.builtin.shell: wrmsr -a 0xc0011029 $(($(rdmsr -c 0xc0011029) | (1<<9)))
+  shell: wrmsr -a 0xc0011029 $(($(rdmsr -c 0xc0011029) | (1<<9)))
   args:
     executable: /bin/bash
   when: matching_cpus.stdout|int > 0


### PR DESCRIPTION
## Summary and Scope

The version of ansible in the AEE in CSM-1.4 (and presumably CSM-1.3) have bugs related to the use of FQCNs. Stop using them.

## Issues and Related PRs

* Resolves [MTL-2281](https://jira-pro.it.hpe.com:8443/browse/MTL-2281)

## Testing

### Tested on:

  * `surtur` @ CSM-1.4.3-beta.4

### Test description:

Ran `apply_csm_configuration.sh` with my test branch.

## Risks and Mitigations

N/A

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

