### PR TITLE
CASMINST-6666 only have csm.storage.smartmon redeploy node-exporter if ceph admin keyring is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- CASMINST-6666: Change the csm.storage.smartmon play so it only redeploys node-exporter if the ceph admin keyring exists.
+- CASMINST-6666: Change the `csm.storage.smartmon` play so it only redeploys `node-exporter` if the ceph admin keyring exists.
 
 ## [1.16.21] - 2023-09-22
 
@@ -343,7 +343,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ansible playbook for applying csm packages to Compute and Application nodes
 
-[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.16.21...HEAD
+[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.16.22...HEAD
+
+[1.16.22]: https://github.com/Cray-HPE/csm-config/compare/1.16.21...1.16.22
 
 [1.16.21]: https://github.com/Cray-HPE/csm-config/compare/1.16.20...1.16.21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.16.22] - 2023-09-26
+
+### Changed
+
+- CASMINST-6666: Change the csm.storage.smartmon play so it only redeploys node-exporter if the ceph admin keyring exists.
+
 ## [1.16.21] - 2023-09-22
 
 ### Changed

--- a/ansible/roles/csm.storage.smartmon/README.md
+++ b/ansible/roles/csm.storage.smartmon/README.md
@@ -22,8 +22,7 @@ Example Playbook
 ----------------
 
 This role runs on all the storage NCNs. It starts the SMART service. It reconfigures and redeploys
-the running `node-exporter` only on `mon[0]` which is `ncn-s001` (to use changed configurations,
-if any). The ceph command to redeploy `node-exporter` can only be run from `ncn-s00[1-3]`.
+the running `node-exporter` if running from a node that has the ceph admin keyring which are nodes `ncn-s00[1-3]`.
 
 ```yaml
 - hosts: Management_Storage

--- a/ansible/roles/csm.storage.smartmon/README.md
+++ b/ansible/roles/csm.storage.smartmon/README.md
@@ -21,8 +21,9 @@ None
 Example Playbook
 ----------------
 
-This role runs on all the storage NCNs. It starts the SMART service, and reconfigures and redeploys
-the running `node-exporter` (to use changed configurations, if any).
+This role runs on all the storage NCNs. It starts the SMART service. It reconfigures and redeploys
+the running `node-exporter` only on `mon[0]` which is `ncn-s001` (to use changed configurations,
+if any). The ceph command to redeploy `node-exporter` can only be run from `ncn-s00[1-3]`.
 
 ```yaml
 - hosts: Management_Storage

--- a/ansible/roles/csm.storage.smartmon/defaults/main.yml
+++ b/ansible/roles/csm.storage.smartmon/defaults/main.yml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -21,24 +21,5 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-# Tasks for the csm.storage.smartmon role
-- name: Start SMART service
-  become: true
-  systemd:
-    name: smart
-    enabled: yes
-    state: started
-
-- name: Check if ceph.client.admin.keyring exists on node
-  stat:
-    path: "{{ ceph_admin_keyring_path }}"
-  register: admin_keyring
-
-- name: Redeploy node-exporter
-  when:
-    - admin_keyring.stat.exists
-  command: "ceph orch {{ item }} "
-  with_items:
-  - apply -i /etc/cray/ceph/node-exporter.yml
-  - reconfig node-exporter
-  - redeploy node-exporter
+# Defaults for the csm.storage.smartmon role. See the README.md for information.
+ceph_admin_keyring_path: '/etc/ceph/ceph.client.admin.keyring'

--- a/ansible/roles/csm.storage.smartmon/defaults/main.yml
+++ b/ansible/roles/csm.storage.smartmon/defaults/main.yml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/ansible/roles/csm.storage.smartmon/tasks/main.yml
+++ b/ansible/roles/csm.storage.smartmon/tasks/main.yml
@@ -30,6 +30,10 @@
     state: started
 
 - name: Redeploy node-exporter
+  when:
+    - groups['mons'] is defined
+  delegate_to: "{{ groups['mons'][0] }}"
+  run_once: true
   command: "ceph orch {{ item }} "
   with_items:
   - apply -i /etc/cray/ceph/node-exporter.yml


### PR DESCRIPTION
## Summary and Scope

This change fixes the csm.storage.smartmon ansible. The Ceph command to redeploy node-exporter does not work when the ceph.client.admin.keyring is not present on the node. This change will only run the redeploy if the admin keyring is present.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMINST-6666](https://jira-pro.it.hpe.com:8443/browse/CASMINST-6666)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Beau - CSM 1.5 vShasta2

### Test description:

Ran a CFS session on a storage nodes with and without the admin keyring. Ensured the CFS role ran as expected.

When the Ceph admin keyring was present, I saw the following

```bash
TASK [csm.storage.smartmon : Check if ceph.client.admin.keyring exists on node] ***
ok: [x3000c0s29b0n0]

TASK [csm.storage.smartmon : Redeploy node-exporter] ***************************
changed: [x3000c0s29b0n0] => (item=apply -i /etc/cray/ceph/node-exporter.yml)
changed: [x3000c0s29b0n0] => (item=reconfig node-exporter)
changed: [x3000c0s29b0n0] => (item=redeploy node-exporter)
```
 When the Ceph admin keyring was NOT present, I saw the following
 ```bash
TASK [csm.storage.smartmon : Check if ceph.client.admin.keyring exists on node] ***
ok: [x3000c0s30b0n0]

TASK [csm.storage.smartmon : Redeploy node-exporter] ***************************
skipping: [x3000c0s30b0n0] => (item=apply -i /etc/cray/ceph/node-exporter.yml)
skipping: [x3000c0s30b0n0] => (item=reconfig node-exporter)
skipping: [x3000c0s30b0n0] => (item=redeploy node-exporter)
```

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

