### PR TITLE
CRAYSAT-1767: Add csm.ncn.sat role to configure SAT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.17.0] - 2023-10-18
+
 ### Dependencies
 
 - Bump `stefanzweifel/git-auto-commit-action` from 4 to 5 ([#212](https://github.com/Cray-HPE/csm-config/pull/212))
@@ -353,7 +355,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ansible playbook for applying csm packages to Compute and Application nodes
 
-[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.16.22...HEAD
+[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.17.0...HEAD
+
+[1.17.0]: https://github.com/Cray-HPE/csm-config/compare/1.16.22...1.17.0
 
 [1.16.22]: https://github.com/Cray-HPE/csm-config/compare/1.16.21...1.16.22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Dependencies
+
 - Bump `stefanzweifel/git-auto-commit-action` from 4 to 5 ([#212](https://github.com/Cray-HPE/csm-config/pull/212))
+
+### Added
+
+- CRAYSAT-1767: Added the role `csm.ncn.sat` for configuration of the System
+  Admin Toolkit (SAT). A similar role for SAT configuraiton was previously only
+  provided by the SAT product.
 
 ## [1.16.22] - 2023-09-26
 

--- a/ansible/ncn-master_nodes.yml
+++ b/ansible/ncn-master_nodes.yml
@@ -58,3 +58,4 @@
     - role: csm.ssh_keys
       vars:
         ssh_keys_username: 'root'
+    - role: csm.ncn.sat

--- a/ansible/ncn-worker_nodes.yml
+++ b/ansible/ncn-worker_nodes.yml
@@ -58,3 +58,4 @@
     - role: csm.ssh_keys
       vars:
         ssh_keys_username: 'root'
+    - role: csm.ncn.sat

--- a/ansible/ncn_nodes.yml
+++ b/ansible/ncn_nodes.yml
@@ -48,7 +48,7 @@
       vars:
         ssh_keys_username: 'root'
 
-# Install packages on Kubernetes NCNs (masters and workers)
+# Install packages and configure SAT on Kubernetes NCNs (masters and workers)
 - hosts:
    - Management_Master
    - Management_Worker
@@ -63,6 +63,7 @@
       vars:
         packages: "{{ common_csm_sles_packages + common_mgmt_ncn_csm_sles_packages + k8s_mgmt_ncn_csm_sles_packages }}"
       when: ansible_distribution_file_variety == "SUSE"
+    - role: csm.ncn.sat
 
 # Install packages on storage NCNs
 - hosts:

--- a/ansible/roles/csm.ncn.sat/README.md
+++ b/ansible/roles/csm.ncn.sat/README.md
@@ -1,0 +1,73 @@
+csm.ncn.sat
+===========
+
+Configure the System Admin Toolkit (SAT) CLI on management non-compute nodes (NCNs).
+
+Requirements
+------------
+
+This role must be run in the context of the CSM Configuration
+Framework Service (CFS) in its Ansible Execution Environment (AEE).
+
+Role Variables
+--------------
+
+Available variables are listed below, along with example values (located in
+`defaults/main.yml` and `vars/main.yml`):
+
+```yaml
+sat_container_image_version_directory: "/opt/cray/etc/sat/"
+```
+
+The directory in which the file containing the `cray-sat` container image
+version will be saved.
+
+```yaml
+sat_container_image_version_file: "version"
+```
+
+The file in which the `cray-sat` container image version will be saved.
+
+```yaml
+sat_config_file: "/root/.config/sat/sat.toml"
+```
+
+The location of the `sat.toml` configuration file, which will have its
+permissions locked down.
+
+```yaml
+sat_container_image_version: "csm-latest"
+```
+
+The `cray-sat` container image version which will be written to the version
+file described above. This variable is set correctly for the CSM version at CSM
+installation time in `vars/main.yml`.
+
+Dependencies
+------------
+
+None
+
+Example Playbook
+----------------
+
+This example playbook configures SAT on the nodes in the groups `Management_Master` and
+`Management_Worker`.
+
+```yaml
+- hosts:
+  - Management_Master
+  - Management_Worker
+  roles:
+  - role: csm.ncn.sat
+```
+
+License
+-------
+
+MIT
+
+Author Information
+------------------
+
+Copyright 2023 Hewlett Packard Enterprise Development LP

--- a/ansible/roles/csm.ncn.sat/defaults/main.yml
+++ b/ansible/roles/csm.ncn.sat/defaults/main.yml
@@ -1,0 +1,33 @@
+#
+# MIT License
+#
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# Defaults for the csm.ncn.sat role. See the README.md for information.
+
+sat_container_image_version_directory: "/opt/cray/etc/sat/"
+sat_container_image_version_file: "version"
+sat_config_file: "/root/.config/sat/sat.toml"
+
+# This variable gets overridden by the value in vars, which is written by the
+# init container in the Helm chart, which gets defined through the Loftsman
+# manifest included in the CSM release distribution.
+sat_container_image_version: "csm-latest"

--- a/ansible/roles/csm.ncn.sat/tasks/main.yml
+++ b/ansible/roles/csm.ncn.sat/tasks/main.yml
@@ -1,0 +1,50 @@
+# MIT License
+#
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# Tasks for the csm.ncn.sat role
+
+- name: "Check if configuration file exists"
+  stat:
+    path: "{{ sat_config_file }}"
+  register: config_file_stat
+
+- name: "Ensure configuration file has 0600 permissions"
+  file:
+    path: "{{ sat_config_file }}"
+    mode: 0600
+  when: config_file_stat.stat.exists
+
+- name: "Ensure tokens directory has 0700 permissions"
+  file:
+    path: "/root/.config/sat/tokens"
+    state: "directory"
+    mode: 0700
+
+- name: "Ensure directory containing SAT container image version file exists"
+  file:
+    path: "{{ sat_container_image_version_directory }}"
+    state: "directory"
+
+- name: "Create file containing SAT container image version"
+  copy:
+    dest: "{{ sat_container_image_version_directory }}/{{ sat_container_image_version_file }}"
+    content: "{{ sat_container_image_version }}"

--- a/ansible/roles/csm.ncn.sat/vars/main.yml
+++ b/ansible/roles/csm.ncn.sat/vars/main.yml
@@ -1,0 +1,30 @@
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# Vars for the csm.ncn.sat role. See the README.md for information.
+#
+# This file gets overwritten by the init container in the Helm chart, which
+# gets defined through the Loftsman manifest included in the CSM release
+# distribution. The file is included here just for illustrative purposes.
+
+sat_container_image_version: "csm-latest"

--- a/ansible/vars/csm_packages.yml
+++ b/ansible/vars/csm_packages.yml
@@ -52,6 +52,7 @@ common_mgmt_ncn_csm_sles_packages:
 # All Kubernetes Management NCNs (master and worker)
 k8s_mgmt_ncn_csm_sles_packages:
   - cray-cmstools-crayctldeploy
+  - cray-sat-podman
   - dracut-metal-dmk8s
   - dracut-metal-luksetcd
 


### PR DESCRIPTION
## Summary and Scope

Add a `csm.ncn.sat` role to configure SAT on Kubernetes management NCNs (masters and workers). This role is being moved from the separate sat-config-management repository into this repository as part of the effort to fully merge the SAT product into the CSM product.

The main differences between the Ansible content as it existed in the SAT product stream and the content added here are as follows:

- The version of the `cray-sat` container image is injected using an initContainer in the Helm chart and a loftsman manifest customization in the CSM release build process.
- There is no longer a separate package repository in Nexus that must be added on management NCNs. The `cray-sat-podman` package is included in the CSM noos repository, and it is installed with the existing csm.packages role.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Part of [CRAYSAT-1767](https://jira-pro.it.hpe.com:8443/browse/CRAYSAT-1767)
* Merge before associated csm PR to be opened still.

## Testing

### Tested on:

  * mug

### Test description:

Deployed the Helm chart to mug, created a CFS configuration with a layer
that called the `ncn_nodes.yml` playbook, then configured a master,
worker, and storage management NCN image with it. Also configured
ncn-m001 with a session using the same CFS configuration. Verified that
the Ansible was successful and the `/opt/cray/etc/sat/version` file was
written as expected, with the value from `vars/main.yml` for the sat
version taking precedence.

## Risks and Mitigations

This should be pretty low-risk. If the SAT layer is run after this layer, the version set by the SAT layer will take precedence. We will want to stop adding the SAT layer.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable