### PR TITLE
CASMINST-6690: update curl to address CVE-2023-38545

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.15.23] - 2023-10-13
+
+### Changed
+
+- CASMINST-6690: update curl to address CVE-2023-38545
+
 ## [1.15.22] - 2023-09-22
 
 ### Changed

--- a/ansible/vars/csm_packages.yml
+++ b/ansible/vars/csm_packages.yml
@@ -30,6 +30,7 @@ ncn_csm_sles_packages:
   - craycli
   - cray-cmstools-crayctldeploy
   - csm-testing
+  - curl
   - goss-servers
   - hpe-csm-goss-package
   - hpe-csm-scripts


### PR DESCRIPTION
## Summary and Scope

Update to the latest curl to address CVE-2023-38545. The patched version of curl will be loaded into nexus.

Pairs with: https://github.com/Cray-HPE/csm/pull/2966

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASMINST-6690

## Testing

### Tested on:

  * `fanta`

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

