### PR TITLE
CASMPET-6860 release/1.16-Deploy node-exporter via cephadm shell in ansible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.16.23] - 2023-11-20
+
+### Changed
+
+- CASMPET-6860: Change the `csm.storage.smartmon` play so it redeploys `node-exporter` using 'cephadm shell' instead of a 'ceph' command.
+
 ## [1.16.22] - 2023-09-26
 
 ### Changed

--- a/ansible/roles/csm.storage.smartmon/tasks/main.yml
+++ b/ansible/roles/csm.storage.smartmon/tasks/main.yml
@@ -37,8 +37,13 @@
 - name: Redeploy node-exporter
   when:
     - admin_keyring.stat.exists
+  command: "cephadm shell --mount /etc/cray/ceph/ -- ceph orch apply -i /mnt/node-exporter.yml"
+  register: apply_node_exporter
+
+- name: Reconfig node-exporter
+  when:
+    - (apply_node_exporter.rc is defined) and (apply_node_exporter.rc == 0)
   command: "ceph orch {{ item }} "
   with_items:
-  - apply -i /etc/cray/ceph/node-exporter.yml
   - reconfig node-exporter
   - redeploy node-exporter


### PR DESCRIPTION
## Summary and Scope

Deploy node-exporter via cephadm shell in ansible that deploys smartmon on storage nodes.
We believe this change is necessary because when applying the CSM 1.4.2 patch on Alvarez, the smartmon enablement on storage nodes script failed. This was likely caused by the ceph-common version on the system. To be able to apply the node-exporter.yml file which enables smartmon, node-exported was deployed via cephadm shell. Applying node exporter via the cephadm shell should work every time and doesn't depend on the ceph-common version installed on the node.

This has been tested on Beau.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-6860](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6860)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Tested on Beau. I applied this CFS configuration to nodes with and without the `admin.keyring` to see that both cases worked.
  Testing was not done on a metal system. This will be tested on every storage node upgrade.

### Test description:

Tested configuring storage nodes with these CFS changes. There were no errors.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

