### PR TITLE
CASMTRIAGE-6370 update csm.storage.smartmon to use specific ceph image when redeploying node-exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -367,7 +367,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ansible playbook for applying csm packages to Compute and Application nodes
 
-[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.17.0...HEAD
+[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.17.2...HEAD
+
+[1.17.2]: https://github.com/Cray-HPE/csm-config/compare/1.17.1...1.17.2
+
+[1.17.1]: https://github.com/Cray-HPE/csm-config/compare/1.17.0...1.17.1
 
 [1.17.0]: https://github.com/Cray-HPE/csm-config/compare/1.16.22...1.17.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.17.2] - 2023-12-05
+
+### Changed
+
+- CASMTRIAGE-6370: Change the `csm.storage.smartmon` play so it redeploys `node-exporter` using a specific image with the cephadm shell.
+
 ## [1.17.1] - 2023-11-20
 
 ### Changed

--- a/ansible/roles/csm.storage.smartmon/defaults/main.yml
+++ b/ansible/roles/csm.storage.smartmon/defaults/main.yml
@@ -23,3 +23,4 @@
 #
 # Defaults for the csm.storage.smartmon role. See the README.md for information.
 ceph_admin_keyring_path: '/etc/ceph/ceph.client.admin.keyring'
+ceph_container_path: 'registry.local/artifactory.algol60.net/csm-docker/stable/quay.io/ceph/ceph'

--- a/ansible/roles/csm.storage.smartmon/tasks/main.yml
+++ b/ansible/roles/csm.storage.smartmon/tasks/main.yml
@@ -34,10 +34,16 @@
     path: "{{ ceph_admin_keyring_path }}"
   register: admin_keyring
 
-- name: Redeploy node-exporter
+- name: Get Ceph version
   when:
     - admin_keyring.stat.exists
-  command: "cephadm shell --mount /etc/cray/ceph/ -- ceph orch apply -i /mnt/node-exporter.yml"
+  shell: "ceph version -f json | jq .version | awk '{ print $3 }'"
+  register: ceph_version
+
+- name: Redeploy node-exporter
+  when:
+    - (ceph_version.rc is defined) and (ceph_version.rc == 0)
+  command: "cephadm --image {{ ceph_container_path }}:v{{ ceph_version.stdout }} shell --mount /etc/cray/ceph/ -- ceph orch apply -i /mnt/node-exporter.yml"
   register: apply_node_exporter
 
 - name: Reconfig node-exporter


### PR DESCRIPTION
## Summary and Scope

**Problem**
On a storage node upgrade on Starlord, cephadm used the incorrect image when trying to redeploy node-exporter. This was likely due to the fact that midway through a storage node upgrade, the cephadm version installed on the node is at a higher version than the Ceph container version that is running. This causes cephadm to look for a default image at 'docker://quay.io/ceph/ceph:v17' which it is unable to find and caused the ansible play to fail.

**Solution/Change**
We can specify the container image that cephadm should use which means it should not look for this default image.

**Notes**
We were not able to prove why cephadm was looking for the ceph image at 'docker://quay.io/ceph/ceph:v17'. I have not replicated this problem and checked that this is indeed the solution. However, this is our best guess as to what is causing the problem.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAGE-6370](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6370)

## Testing

### Tested on:

  * Beau, CSM 1.6 vShasta2

### Test description:

I ran this ansible play on storage that contained the ceph admin keyring, which means this play would run all the way through. I also ran the play on storage nodes that did not have the ceph admin keyring which means this play would be skipped. Both tests worked. CFS logs are below for both cases.

Output when storage node had ceph admin keyring
```
TASK [csm.storage.smartmon : Get Ceph version] *********************************
changed: [x3000c0s30b0n0]

TASK [csm.storage.smartmon : Redeploy node-exporter] ***************************
changed: [x3000c0s30b0n0]

TASK [csm.storage.smartmon : Reconfig node-exporter] ***************************
changed: [x3000c0s30b0n0] => (item=reconfig node-exporter)
changed: [x3000c0s30b0n0] => (item=redeploy node-exporter)

PLAY RECAP *********************************************************************
x3000c0s30b0n0             : ok=23   changed=8    unreachable=0    failed=0    skipped=5    rescued=3    ignored=0

All playbooks completed successfully
```

Output when storage node did not have ceph admin keyring
```
PLAY [Management_Storage:!cfs_image] *******************************************

PLAY RECAP *********************************************************************
x3000c0s31b0n0             : ok=20   changed=5    unreachable=0    failed=0    skipped=8    rescued=3    ignored=0

All playbooks completed successfully
```

## Risks and Mitigations

I did not get a chance to test this on metal to make sure it solves the problem. However, this will be tested on our internal CSM 1.4 to 1.5 upgrades.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

