### PR TITLE
MTL-2348 Marvell/SuSE Fixes for Failed NIC Recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -228,7 +228,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ansible playbook for applying csm packages to Compute and Application nodes
 
-[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.15.21...HEAD
+[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.15.24...HEAD
+
+[1.15.24]: https://github.com/Cray-HPE/csm-config/compare/1.15.23...1.15.24
+
+[1.15.23]: https://github.com/Cray-HPE/csm-config/compare/1.15.22...1.15.23
+
+[1.15.22]: https://github.com/Cray-HPE/csm-config/compare/1.15.21...1.15.22
 
 [1.15.21]: https://github.com/Cray-HPE/csm-config/compare/1.15.20...1.15.21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.15.24] - 2024-01-24
+
+- [MTL-2348](https://jira-pro.it.hpe.com:8443/browse/MTL-2348: New `ncn_kernel_upgrade` role. This role is now included in the `ncn_initrd.yml` playbook. These changes will
+  enforce the installation of the new SuSE PTF Kernel and Marvell KMP. Module tweaks are also included, preventing `qedr`
+  from loading during the rootfs, as well as being excluded from dracut.
+
 ## [1.15.23] - 2023-10-13
 
 ### Changed

--- a/ansible/ncn-initrd.yml
+++ b/ansible/ncn-initrd.yml
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -22,11 +22,61 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-# NCN Worker Nodes Play
+
+#
+## CSM 1.4.4 SuSE PTF and Marvell KMP patch for Kubernetes nodes
+#
+- hosts: "Management_Master:Management_Worker:Management_Storage:&cfs_image"
+  gather_facts: true
+  # Gather the minimum that gets the ansible_distribution variable set
+  gather_subset:
+    - '!all'
+    - '!min'
+    - distribution
+  any_errors_fatal: true
+  remote_user: root
+  vars:
+
+    kernel_version: 5.14.21-150400.24.100.2.27359.1.PTF.1215587
+
+    packages:
+      - qlgc-fastlinq-kmp-default=8.74.1.0_k5.14.21_150400.22-1.sles15sp4
+
+  vars_files:
+    - vars/csm_repos.yml
+
+  roles:
+
+    - role: ncn_kernel_upgrade
+      when:
+        - ansible_distribution_file_variety == "SUSE"
+        - ansible_distribution_version == "15.4"
+      vars:
+        ncn_kernel_upgrade_kernel_version: "{{ kernel_version }}"
+        ncn_kernel_upgrade_repositories: "{{ csm_sles_repositories }}"
+
+    # Ensure the HPE-SDR key is imported for the Marvell packages to install.
+    - role: csm.gpg_keys
+      vars:
+        csm_gpg_key_k8s_secret: "hpepublickey"
+
+    - role: csm.packages
+      when:
+        - ansible_distribution_file_variety == "SUSE"
+        - ansible_distribution_version == "15.4"
+      vars:
+        csm_sles_packages: "{{ packages }}"
+
+  post_tasks:
+
+    - name: Remove fastlinq conf
+      file:
+        path: /etc/dracut.conf.d/fastlinq.conf
+        state: absent
+
 - hosts: "Management_Master:Management_Worker:Management_Storage:&cfs_image"
   any_errors_fatal: true
   remote_user: root
-
   roles:
     # Creates an NCN initrd during pre-boot image customization
     - role: csm.ncn-initrd

--- a/ansible/roles/ncn_kernel_upgrade/defaults/main.yml
+++ b/ansible/roles/ncn_kernel_upgrade/defaults/main.yml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -21,25 +21,13 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-# Tasks for the csm.packages role
-- name: Configure CSM RPM Repos (SLES-based)
-  zypper_repository:
-    name: "{{ item.name }}"
-    description: "{{ item.description }}"
-    repo: "{{ item.repo }}"
-    state: present
-    disable_gpg_check: "{{ item.disable_gpg_check | default('no') }}"
-  loop: "{{ csm_sles_repositories }}"
-
-# CSM repos are generated during the release distribution creation and
-# therefore repo metadata is not signed. Allow for the repo metadata to be
-# unsigned, but still check the signature on individual packages.
-- name: Allow unsigned repo metadata
-  command: "zypper modifyrepo --gpgcheck-allow-unsigned-repo {{ item.name }}"
-  loop: "{{ csm_sles_repositories }}"
-
-- name: Install RPMs (SLES-based)
-  zypper:
-    name: "{{ packages }}"
-    state: latest
-    update_cache: yes
+ncn_kernel_upgrade_blacklist:
+  - qedr
+ncn_kernel_upgrade_kernel_version: ''
+ncn_kernel_upgrade_repositories: []
+ncn_kernel_upgrade_packages:
+  - "kernel-default-devel={{ ncn_kernel_upgrade_kernel_version }}"
+  - "kernel-default={{ ncn_kernel_upgrade_kernel_version }}"
+  - "kernel-devel={{ ncn_kernel_upgrade_kernel_version }}"
+  - "kernel-macros={{ ncn_kernel_upgrade_kernel_version }}"
+  - "kernel-syms={{ ncn_kernel_upgrade_kernel_version }}"

--- a/ansible/roles/ncn_kernel_upgrade/handlers/main.yml
+++ b/ansible/roles/ncn_kernel_upgrade/handlers/main.yml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -21,25 +21,12 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-# Tasks for the csm.packages role
-- name: Configure CSM RPM Repos (SLES-based)
-  zypper_repository:
-    name: "{{ item.name }}"
-    description: "{{ item.description }}"
-    repo: "{{ item.repo }}"
-    state: present
-    disable_gpg_check: "{{ item.disable_gpg_check | default('no') }}"
-  loop: "{{ csm_sles_repositories }}"
+- name: Zypper purge kernels
+  command: zypper --non-interactive purge-kernels --details
+  register: purge
+  changed_when: '"The following package is going to be REMOVED" in purge.stdout'
 
-# CSM repos are generated during the release distribution creation and
-# therefore repo metadata is not signed. Allow for the repo metadata to be
-# unsigned, but still check the signature on individual packages.
-- name: Allow unsigned repo metadata
-  command: "zypper modifyrepo --gpgcheck-allow-unsigned-repo {{ item.name }}"
-  loop: "{{ csm_sles_repositories }}"
-
-- name: Install RPMs (SLES-based)
-  zypper:
-    name: "{{ packages }}"
-    state: latest
-    update_cache: yes
+- name: Zypper lock kernel-default
+  command: "zypper addlock kernel-default"
+  register: addlock
+  changed_when: '"Specified lock has been successfully added." in addlock.stdout'

--- a/ansible/roles/ncn_kernel_upgrade/tasks/main.yml
+++ b/ansible/roles/ncn_kernel_upgrade/tasks/main.yml
@@ -1,0 +1,91 @@
+#
+# MIT License
+#
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+---
+- name: SUSE Packages
+  when: ansible_distribution_file_variety == "SUSE"
+  block:
+
+    - name: Configure CSM RPM Repos (SLES-based)
+      zypper_repository:
+        name: "{{ item.name }}"
+        description: "{{ item.description }}"
+        repo: "{{ item.repo }}"
+        state: present
+        disable_gpg_check: "{{ item.disable_gpg_check | default('false') }}"
+      loop: "{{ ncn_kernel_upgrade_repositories }}"
+
+    - name: Allow unsigned repo metadata
+      command: "zypper modifyrepo --gpgcheck-allow-unsigned-repo {{ item.name }}"
+      loop: "{{ ncn_kernel_upgrade_repositories }}"
+
+    - name: Unlock kernel-default
+      command: "zypper removelock kernel-default"
+      register: removelock
+      changed_when: '"1 lock has been successfully removed." in removelock.stdout'
+      notify: "ncn_kernel_upgrade : Zypper lock kernel-default"
+      args:
+        warn: false
+
+    - name: Install RPMs (SLES-based)
+      zypper:
+        disable_recommends: true
+        oldpackage: true
+        state: present
+        type: package
+        name: "{{ ncn_kernel_upgrade_packages }}"
+        update_cache: false
+      register: install
+      changed_when: '"Reboot is suggested to ensure that your system benefits from these updates." in install.stdout'
+      failed_when:
+        - install.rc != 0
+        - install.rc != 107
+
+    - name: Update multiversion.kernels
+      lineinfile:
+        create: true
+        mode: '0644'
+        path: /etc/zypp/zypp.conf
+        regexp: '^#? ?multiversion\.kernels =.*'
+        line: 'multiversion.kernels = {{ ncn_kernel_upgrade_kernel_version }}'
+        state: present
+      notify: "ncn_kernel_upgrade : Zypper purge kernels"
+
+- name: Blacklist kernel modules
+  lineinfile:
+    create: true
+    mode: '0644'
+    path: /etc/modprobe.d/disabled-modules.conf
+    regexp: 'install {{ item }} .*'
+    line: 'install {{ item }} /bin/true'
+    state: present
+  loop: "{{ ncn_kernel_upgrade_blacklist }}"
+
+- name: Blacklist kernel modules from dracut
+  lineinfile:
+    create: true
+    mode: '0644'
+    path: /etc/dracut.conf.d/99-csm-ansible.conf
+    regexp: '^omit_drivers\+=.*'
+    line: 'omit_drivers+=" {{ ncn_kernel_upgrade_blacklist | join(" ") }} " # Needs to start and end with a space to mitigate warnings. '
+    state: present


### PR DESCRIPTION
### Summary

New roles and updates to `ncn_initrd.yml` for installing new packages pertaining to NIC
failures:
- New SuSE PTF Kernel mitigating Kernel Panics for any vendor during NIC recovery
- New Marvell driver with bugfixes for successfully recovering bonded QLogic NICs

### Testing

System: groot

Resulting `rootfs` had:
- New QLogic KMP
- New Kernel
- All old kernels were purged
- `multiversion.kernels` was updated in `/etc/zypp/zypp.conf`
- `qedr` appeared in both `/etc/modprobe.d/disabled-modules.conf` and `/etc/dracut.conf.d/99-csm-ansible.conf`
- `/etc/dracut.conf.d/fastlinq.conf` was removed

```bash
ncn-m001:/ # rpm -qa kernel-default
kernel-default-5.14.21-150400.24.100.2.27359.1.PTF.1215587.x86_64
ncn-m001:/ # rpm -qa qlgc
ncn-m001:/ # rpm -q qlgc-fastlinq-kmp-default
qlgc-fastlinq-kmp-default-8.74.1.0_k5.14.21_150400.22-1.sles15sp4.x86_64
ncn-m001:/ # cat /etc/dracut.conf.d/99-csm-ansible.conf
omit_drivers+=" qedr " # Needs to start and end with a space to mitigate warnings.
ncn-m001:/ # grep qedr /etc/modprobe.d/disabled-modules.conf
install qedr /bin/true
ncn-m001:/ # grep -E '^multiversion\.kernels' /etc/zypp/zypp.conf
multiversion.kernels = 5.14.21-150400.24.100.2.27359.1.PTF.1215587
```

Resulting `kernel` in S3 matched.

```bash
ncn-m001:/mnt/developer/doomslayer/staging # file kernel
kernel: Linux/x86 Kernel, Setup Version 0x20f, bzImage, Version 5.14.21-150400.24.100.2.27359.1.PTF.1215587-default (geeko@buildhost) #1 SMP PREEMPT_DYNAMIC Mo, RO-rootFS, swap_dev 0xA, Normal VGA
```

Resulting `initrd` in S3 had:
- The new QLogic kernel modules
- No `qedr` module
- Even with `/etc/dracut.conf.d/fastlinq.conf` removed, the necessary `qed*` modules were included (excluding `qedr`)

```bash
incn-m001:/mnt/developer/doomslayer/staging # lsinitrd initrd | grep qedr
ncn-m001:/mnt/developer/doomslayer/staging # lsinitrd initrd | grep qede
drwxr-xr-x   2 root     root            0 Jan 23 16:16 lib/modules/5.14.21-150400.24.100.2.27359.1.PTF.1215587-default/kernel/drivers/net/ethernet/qlogic/qede
-rw-r--r--   1 root     root       112364 Dec 18 21:38 lib/modules/5.14.21-150400.24.100.2.27359.1.PTF.1215587-default/kernel/drivers/net/ethernet/qlogic/qede/qede.ko.zst
ncn-m001:/mnt/developer/doomslayer/staging # lsinitrd initrd | grep qede
drwxr-xr-x   2 root     root            0 Jan 23 16:16 lib/modules/5.14.21-150400.24.100.2.27359.1.PTF.1215587-default/kernel/drivers/net/ethernet/qlogic/qede
-rw-r--r--   1 root     root       112364 Dec 18 21:38 lib/modules/5.14.21-150400.24.100.2.27359.1.PTF.1215587-default/kernel/drivers/net/ethernet/qlogic/qede/qede.ko.zst
```