### PR TITLE
MTL-2348 Fixes QLogic Boots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.15.26] - 2024-01-30
+
+- [MTL-2348](https://jira-pro.it.hpe.com:8443/browse/MTL-2348): Ensure QLogic modules are included in initrd with the absence of `fastlinq.conf`, otherwise QLogic nodes will not boot.
+
 ## [1.15.25] - 2024-01-26
 
 - [MTL-2348](https://jira-pro.it.hpe.com:8443/browse/MTL-2348): Use different Kubernetes secret
@@ -233,6 +237,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ansible playbook for applying csm packages to Compute and Application nodes
 
 [Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.15.24...HEAD
+
+[1.15.26]: https://github.com/Cray-HPE/csm-config/compare/1.15.25...1.15.26
 
 [1.15.25]: https://github.com/Cray-HPE/csm-config/compare/1.15.24...1.15.25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -236,7 +236,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ansible playbook for applying csm packages to Compute and Application nodes
 
-[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.15.24...HEAD
+[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.15.26...HEAD
 
 [1.15.26]: https://github.com/Cray-HPE/csm-config/compare/1.15.25...1.15.26
 

--- a/ansible/roles/ncn_kernel_upgrade/defaults/main.yml
+++ b/ansible/roles/ncn_kernel_upgrade/defaults/main.yml
@@ -21,6 +21,11 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+ncn_kernel_upgrade_add:
+  - qed
+  - qede
+  - qedf
+  - qedi
 ncn_kernel_upgrade_blacklist:
   - qedr
 ncn_kernel_upgrade_kernel_version: ''

--- a/ansible/roles/ncn_kernel_upgrade/tasks/main.yml
+++ b/ansible/roles/ncn_kernel_upgrade/tasks/main.yml
@@ -56,7 +56,9 @@
         name: "{{ ncn_kernel_upgrade_packages }}"
         update_cache: false
       register: install
-      changed_when: '"Reboot is suggested to ensure that your system benefits from these updates." in install.stdout'
+      changed_when:
+      - install.stdout is defined
+      - '"Reboot is suggested to ensure that your system benefits from these updates." in install.stdout'
       failed_when:
         - install.rc != 0
         - install.rc != 107
@@ -88,4 +90,13 @@
     path: /etc/dracut.conf.d/99-csm-ansible.conf
     regexp: '^omit_drivers\+=.*'
     line: 'omit_drivers+=" {{ ncn_kernel_upgrade_blacklist | join(" ") }} " # Needs to start and end with a space to mitigate warnings. '
+    state: present
+
+- name: Include kernel modules in dracut
+  lineinfile:
+    create: true
+    mode: '0644'
+    path: /etc/dracut.conf.d/99-csm-ansible.conf
+    regexp: '^add_drivers\+=.*'
+    line: 'add_drivers+=" {{ ncn_kernel_upgrade_add | join(" ") }} " # Needs to start and end with a space to mitigate warnings. '
     state: present


### PR DESCRIPTION
QLogic cards are not showing in the initramfs, the `qede` module is
failing to load.

This was root caused by the removal of `fastlinq.conf`.

We still have to remove `fastlinq.conf`, as it installs `qedr` and
overrides our blacklist.

The QLogic modules must be specified for the necessary weak-updates to be installed into the initramfs.

This adds all the modules from `fastlinq.conf`, excluding `qedr`.
