### PR TITLE
CASMCMS-8924: Fixed typo in ansible/ims_computes.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed typo in `ansible/ims_computes.yml`
+
 ## [1.17.9] - 2024-02-23
 
 ### Changed

--- a/ansible/ims_computes.yml
+++ b/ansible/ims_computes.yml
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -31,7 +31,7 @@
   remote_user: root
   vars_files:
     - vars/csm_ims_repos.yml
-    - vars/csm_packages.yyml
+    - vars/csm_packages.yml
   roles:
     - role: csm.packages
       vars: 


### PR DESCRIPTION
Simple uncontroversial typo fix