### PR TITLE
SKERN-9239: Added password-less ssh to CN/UAN to CSM layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- SKERN-9239: Added password-less ssh to CN/UAN to CSM layer
+
 ## [1.17.11] - 2024-03-04
 
 - Added support for `aarch64` IMS remote nodes

--- a/ansible/csm_packages.yml
+++ b/ansible/csm_packages.yml
@@ -52,6 +52,8 @@
       vars:
         packages: "{{ common_csm_sles_packages + application_csm_sles_packages }}"
       when: ansible_distribution_file_variety == "SUSE"
+    - role: csm.ca_cert
+    - role: trust-csm-ssh-keys
   tasks:
     - name: Add CSM services to presets file
       loop: "{{ csm_services }}"
@@ -100,6 +102,8 @@
       vars:
         packages: "{{ common_csm_sles_packages + compute_csm_sles_packages }}"
       when: ansible_distribution_file_variety == "SUSE"
+    - role: csm.ca_cert
+    - role: trust-csm-ssh-keys
   tasks:
     - name: Add CSM services to presets file
       loop: "{{ csm_services }}"


### PR DESCRIPTION


## Summary and Scope

Password-less ssh to CN/UAN is moved to CSM layer from USS layer.

This change backwards compatible and have it should not affect the older compute node config.

## Issues and Related PRs

* Resolves [SKERN-9239](https://jira-pro.it.hpe.com:8443/browse/SKERN-9239)

## Testing

CFS layers for USS and CSM needs to be manually applied to Odin's CN/UAN configurations.

### Tested on:

  * `Odin`

### Test description:

Generated boot image using the updated CFS configs, booted CN/UAN to make sure password-less ssh works.  Ansible log is verified for this move.

## Risks and Mitigations

USS will remove the passwordless config from USS layer and it depends on this mod to make the CN/UAN passwordless to work.


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

