### PR TITLE
add noos repositories, add functionality to add both ssh keys, ims sp…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.16.29] - 2024-04-26
+
+### Fixed
+
+- Fixed regression where package installation would fail
+- Allow multiple SSH keys in authorized keys file
+
 ## [1.16.28] - 2024-03-05
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed regression where package installation would fail
+- Fixed regression where package installation would fail CASMTRIAGE-6935
 - Allow multiple SSH keys in authorized keys file
 
 ## [1.16.28] - 2024-03-05

--- a/ansible/ims_computes.yml
+++ b/ansible/ims_computes.yml
@@ -37,6 +37,6 @@
     - role: csm.gpg_keys
     - role: csm.packages
       vars:
-        packages: "{{ ims_compute_sles_packages + common_csm_sles_packages }}"
+        packages: "{{ ims_compute_sles_packages }}"
     - role: csm.ims-remote
     - role: csm.rebuild-initrd

--- a/ansible/roles/csm.ims-remote/defaults/main.yml
+++ b/ansible/roles/csm.ims-remote/defaults/main.yml
@@ -22,5 +22,12 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 # Defaults for the csm.ims-remote role. See the README.md for information.
-
-
+ssh_keys_vault_url: 'http://cray-vault.vault:8200'
+ssh_keys_vault_jwt_file: '/var/run/secrets/kubernetes.io/serviceaccount/token'
+ssh_keys_vault_role_file: '/var/run/secrets/kubernetes.io/serviceaccount/namespace'
+ssh_keys_user_private_key_secret_prefix: 'secret/csm/users/'
+ssh_keys_user_private_key_key: 'ssh_private_key'
+ssh_keys_user_public_key_secret_prefix: 'secret/csm/users/'
+ssh_keys_user_public_key_key: 'ssh_public_key'
+ssh_keys_username: 'root'
+ssh_keys_keytype: 'rsa'

--- a/ansible/roles/csm.ims-remote/tasks/main.yml
+++ b/ansible/roles/csm.ims-remote/tasks/main.yml
@@ -23,8 +23,65 @@
 #
 # Tasks for the csm.ims-remote role
 ---
+- name: Get vault token
+  no_log: true
+  uri:
+    url: "{{ ssh_keys_vault_url }}/v1/auth/kubernetes/login"
+    method: POST
+    body:
+      jwt: "{{ lookup('file', ssh_keys_vault_jwt_file) }}"
+      role: "{{ lookup('file', ssh_keys_vault_role_file) }}"
+    body_format: json
+  register: vault_login
+  delegate_to: localhost
+  run_once: true
 
-- name: Get SSH certificate
+- name: Retrieve the ssh private key
+  block:
+    - name: Lookup the private key value in Vault
+      no_log: true
+      run_once: true
+      delegate_to: localhost
+      set_fact:
+        ssh_priv_key: "{{ lookup('hashi_vault',
+                      'secret=' + ssh_keys_user_private_key_secret_prefix + ssh_keys_username + ':' + ssh_keys_user_private_key_key +
+                      ' token=' + vault_login.json.auth.client_token +
+                      ' url=' + ssh_keys_vault_url) }}"
+  rescue:
+    - name: set the value if no private key was found
+      set_fact:
+        ssh_priv_key: ''
+
+- name: Retrieve the ssh public key
+  block:
+    - name: Lookup the public key value in Vault
+      run_once: true
+      delegate_to: localhost
+      set_fact:
+        ssh_pub_key: "{{ lookup('hashi_vault',
+                     'secret=' + ssh_keys_user_public_key_secret_prefix + ssh_keys_username + ':' + ssh_keys_user_public_key_key +
+                     ' token=' + vault_login.json.auth.client_token +
+                     ' url=' + ssh_keys_vault_url) }}"
+  rescue:
+    - name: set the value if no public key was found
+      set_fact:
+        ssh_pub_key: ''
+
+- name: Determine if play will go on
+  debug: msg="Neither a private or public key exist in Vault for the {{ ssh_keys_username }} user. Exiting without error."
+  when: ssh_pub_key == '' and ssh_priv_key == ''
+
+- name: End play if neither key exists in Vault
+  meta: end_play
+  when: ssh_pub_key == '' and ssh_priv_key == ''
+
+- name: Ensure the user exists
+  user:
+    name: "{{ ssh_keys_username }}"
+    state: present
+  register: user_registered
+
+- name: Get ims public key
   local_action:
     module: csm_read_configmap
     name: cray-ims-remote-keys
@@ -43,5 +100,24 @@
   authorized_key:
     state: present
     user: root
-    key: "{{ public_key.response }}"
+    key: "{{ ssh_pub_key + public_key.response }}"
   when: public_key != ''
+
+- name: Copy the public key
+  copy:
+    content: "{{ ssh_pub_key }}\n"
+    dest: "{{ user_registered.home }}/.ssh/id_{{ ssh_keys_keytype }}.pub"
+    mode: 0644
+  become: true
+  become_user: "{{ ssh_keys_username }}"
+  when: ssh_pub_key != ''
+
+- name: Copy the private key
+  no_log: true
+  copy:
+    content: "{{ ssh_priv_key }}\n"
+    dest: "{{ user_registered.home }}/.ssh/id_{{ ssh_keys_keytype }}"
+    mode: 0600
+  become: true
+  become_user: "{{ ssh_keys_username }}"
+  when: ssh_priv_key != ''

--- a/ansible/vars/csm_ims_repos.yml
+++ b/ansible/vars/csm_ims_repos.yml
@@ -38,3 +38,6 @@ csm_sles_repositories:
 - name: SUSE-SLE-Module-Basesystem-${releasever_major}-SP${releasever_minor}-x86_64-Pool
   description: "SUSE Basesystem Modules (added by Ansible)"
   repo: https://packages.local/repository/SUSE-SLE-Module-Basesystem-${releasever_major}-SP${releasever_minor}-x86_64-Pool
+- name: csm-noos
+  description: "CSM No-OS Packages (added by Ansible)"
+  repo: https://packages.local/repository/csm-noos

--- a/ansible/vars/csm_packages.yml
+++ b/ansible/vars/csm_packages.yml
@@ -79,3 +79,12 @@ compute_csm_sles_packages:
 # IMS Remote Compute Nodes:
 ims_compute_sles_packages:
   - podman
+  - cfs-debugger
+  - cfs-state-reporter
+  - cfs-trust
+  - craycli
+  - csm-auth-utils
+  - csm-node-heartbeat
+  - csm-node-identity
+  - spire-agent>=1.5.0
+  - tpm-provisioner-client


### PR DESCRIPTION
## Summary and Scope
Regression in 1.5.1 caused errors with package installation.
Noos repository has been added. Multiple SSH keys in authorized keys file has been added. Package list for remote build no longer uses common_sles_packages as installing hpe-yq on MTL image resulted in errors

## Issues and Related PRs

https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6935

## Testing

### Tested on:

Drax

### Test description:
Tested ansible configuration and booting of the image. David confirmed working image with remote builds and customizations. SSH from ncn is possible with the use of the key in the ~/.ssh/ directory.

## Risks and Mitigations

No


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

