### PR TITLE
CASMTRIAGE-6992

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- 'statedir' environment variable to support a newer version of the ca-certificates rpm
+
 ## [1.18.0] - 2024-03-20
 
 ### Added

--- a/ansible/roles/csm.ca_cert/tasks/main.yml
+++ b/ansible/roles/csm.ca_cert/tasks/main.yml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/ansible/roles/csm.ca_cert/tasks/main.yml
+++ b/ansible/roles/csm.ca_cert/tasks/main.yml
@@ -60,9 +60,10 @@
     ansible_distribution_version != "15.2" and
     cert_file.stat.exists
 
-
 - name: Run certificate update scripts
   command: "{{ item.path }}"
+  environment:
+    statedir: "/var/lib/ca-certificates"
   loop: "{{ ca_scripts.files }}"
   when: >
     ansible_distribution_file_variety == "SUSE" and


### PR DESCRIPTION
## Summary and Scope

The newest ca-certificates rpm uses/requires the **statedir** environment variable to be set. Under normal circumstances the update-ca-certificates script sets the variable and executes all of the *.run scripts in /usr/lib/ca-certificates/update.d/.  Since we don't use the update-ca-certificates script, we have to set the statedir variable. The changes in this PR are backwards compatible.

This statedir variable change was introduced in ca-certificates-2+git20240416.98ae794-150300.4.3.3
We are currently running ca-certificates-2+git20210309.21162a6-2.1

## Issues and Related PRs

https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-6992

## Testing

### Tested on:

  * gamora

### Test description:

The ca-cert ansible role was modified with the same changes in this PR. The play was successful.

## Risks and Mitigations

None known.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] Testing is appropriate and complete, if applicable
