### PR TITLE
CASMINST-6896: Support multiple GPG signing keys and install them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -413,7 +413,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ansible playbook for applying csm packages to Compute and Application nodes
 
-[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.16.32...HEAD
+[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.16.33...HEAD
+
+[1.16.33]: https://github.com/Cray-HPE/csm-config/compare/1.16.32...1.16.33
 
 [1.16.32]: https://github.com/Cray-HPE/csm-config/compare/1.16.31...1.16.32
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.16.33] - 2024-06-26
+
+### Added
+
+- CASMINST-6896: Add support for multiple GPG keys and update with CFS
+
 ## [1.16.32] - 2024-05-30
 
 ### Added

--- a/ansible/compute_nodes.yml
+++ b/ansible/compute_nodes.yml
@@ -35,7 +35,6 @@
   roles:
     - role: csm.ca_cert
     - role: csm.password
-    - role: csm.gpg_keys
     - role: csm.ssh_keys
     - role: csm.cn.exclude-module
 

--- a/ansible/roles/csm.gpg_keys/README.md
+++ b/ansible/roles/csm.gpg_keys/README.md
@@ -47,4 +47,4 @@ MIT
 Author Information
 ------------------
 
-Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+Copyright 2021-2024 Hewlett Packard Enterprise Development LP

--- a/ansible/roles/csm.gpg_keys/README.md
+++ b/ansible/roles/csm.gpg_keys/README.md
@@ -1,15 +1,15 @@
 csm.gpg_keys
 =========
 
-Install the CSM GPG signing public key. This role is a dependency of the
+Install the CSM GPG signing public keys. This role is a dependency of the
 `csm.packages` role.
 
 Requirements
 ------------
 
-The Kubernetes secret must be available in the namespace and field specified
-by the `csm_gpg_key_*` variables below. The key must be stored as a base64-encoded
-string.
+The Kubernetes secret must be available in the namespace specified
+by the `csm_gpg_key_*` variables below. Each field in secret is processed as separate
+GPG signing key. Keys must be stored as base64-encoded string.
 
 Role Variables
 --------------
@@ -25,9 +25,6 @@ The Kubernetes secret which contains the GPG public key.
 
 The Kubernetes namespace which contains the secret.
 
-    csm_gpg_key_k8s_field: "gpg-pubkey"
-
-The field in the Kubernetes secret that holds the GPG public key.
 
 Dependencies
 ------------

--- a/ansible/roles/csm.gpg_keys/defaults/main.yml
+++ b/ansible/roles/csm.gpg_keys/defaults/main.yml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -24,4 +24,3 @@
 # Defaults for the csm.gpg_key role. See the README.md for information.
 csm_gpg_key_k8s_secret: "hpe-signing-key"
 csm_gpg_key_k8s_namespace: "services"
-csm_gpg_key_k8s_field: "gpg-pubkey"

--- a/ansible/roles/csm.gpg_keys/tasks/install_key.yml
+++ b/ansible/roles/csm.gpg_keys/tasks/install_key.yml
@@ -1,8 +1,7 @@
-#!/usr/bin/env ansible-playbook
 #
 # MIT License
 #
-# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -22,22 +21,19 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-- hosts: Application:Compute:&cfs_image
-  gather_subset:
-    - '!all'
-    - '!min'
-    - distribution
-  any_errors_fatal: true
-  remote_user: root
-  vars_files:
-    - vars/csm_ims_repos.yml
-    - vars/csm_packages.yml
-  roles:
-    - role: csm.ca_cert
-    - role: csm.packages
-      vars:
-        packages: "{{ ims_compute_sles_packages }}"
-    - role: csm.ims-remote
-    - role: trust-csm-ssh-keys
-    - role: passwordless-ssh
-    - role: csm.rebuild-initrd
+
+- name: Create a temporary file to store the key content
+  tempfile:
+    state: file
+    suffix: key
+  register: temp_key_file
+
+- name: Copy the key content to a temporary file
+  copy:
+    content: "{{ item.value | b64decode }}"
+    dest: "{{ temp_key_file.path }}"
+
+- name: Install the HPE Signing Key
+  rpm_key:
+    state: present
+    key: "{{ temp_key_file.path }}"

--- a/ansible/roles/csm.gpg_keys/tasks/main.yml
+++ b/ansible/roles/csm.gpg_keys/tasks/main.yml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -22,28 +22,14 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 # Tasks for the csm.gpg_keys role
-- name: Fetch the HPE GPG Signing Key from the K8S secret
+- name: Fetch Public GPG Keys from the K8S secret
   no_log: true
   local_action:
     module: csm_read_secret
     name: "{{ csm_gpg_key_k8s_secret }}"
     namespace: "{{ csm_gpg_key_k8s_namespace }}"
-    key: "{{ csm_gpg_key_k8s_field }}"
-    decrypt: True
-  register: hpe_gpg_pubkey
+  register: hpe_gpg_pubkeys
 
-- name: Create a temporary file to store the key content
-  tempfile:
-    state: file
-    suffix: key
-  register: temp_key_file
-
-- name: Copy the key content to a temporary file
-  copy:
-    content: "{{ hpe_gpg_pubkey.response }}"
-    dest: "{{ temp_key_file.path }}"
-
-- name: Install the HPE Signing Key
-  rpm_key:
-    state: present
-    key: "{{ temp_key_file.path }}"
+- include_tasks: install_key.yml
+  no_log: true
+  loop: "{{ hpe_gpg_pubkeys.response | dict2items }}"

--- a/ansible/roles/csm.packages/meta/main.yml
+++ b/ansible/roles/csm.packages/meta/main.yml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/ansible/roles/csm.packages/meta/main.yml
+++ b/ansible/roles/csm.packages/meta/main.yml
@@ -1,4 +1,3 @@
-#!/usr/bin/env ansible-playbook
 #
 # MIT License
 #
@@ -22,22 +21,5 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-- hosts: Application:Compute:&cfs_image
-  gather_subset:
-    - '!all'
-    - '!min'
-    - distribution
-  any_errors_fatal: true
-  remote_user: root
-  vars_files:
-    - vars/csm_ims_repos.yml
-    - vars/csm_packages.yml
-  roles:
-    - role: csm.ca_cert
-    - role: csm.packages
-      vars:
-        packages: "{{ ims_compute_sles_packages }}"
-    - role: csm.ims-remote
-    - role: trust-csm-ssh-keys
-    - role: passwordless-ssh
-    - role: csm.rebuild-initrd
+dependencies:
+  - role: csm.gpg_keys


### PR DESCRIPTION
## Summary and Scope

Add multiple GPG keys via CFS
Most of this code was written by @mtupitsyn, I just borrowed it.

## Issues and Related PRs

- https://jira-pro.it.hpe.com:8443/browse/CASMINST-6896
- This is targeted for CSM 1.5. It is a backport of: https://github.com/Cray-HPE/csm-config/pull/277

## Testing

node-personalization and image customization were both successful

### Tested on:

- tyr

## Risks and Mitigations

none known

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable