### PR TITLE
MTL-2405 - re-add XFS mount changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.15.32] - 2024-07-05
+
+- MTL-2405: re-add xfs mount changes.
+
 ## [1.15.31] - 2024-07-05
 
 - CASMINST-6896: Support for multiple gpg keys.
@@ -259,7 +263,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Ansible playbook for applying csm packages to Compute and Application nodes
+[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.15.32...HEAD
+
+[1.15.32]: https://github.com/Cray-HPE/csm-config/compare/1.15.31...1.15.32
 
 [Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.15.31...HEAD
 

--- a/ansible/ncn_nodes.yml
+++ b/ansible/ncn_nodes.yml
@@ -54,3 +54,4 @@
     - role: csm.ssh_keys
       vars:
         ssh_keys_username: 'root'
+    - role: csm.ncn.fs_mount_options

--- a/ansible/roles/csm.ncn.fs_mount_options/defaults/main.yml
+++ b/ansible/roles/csm.ncn.fs_mount_options/defaults/main.yml
@@ -1,0 +1,24 @@
+# MIT License
+#
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+---
+var_lib_container_mount: '[ LABEL=CONTAIN, /var/lib/containers, auto, defaults ]'

--- a/ansible/roles/csm.ncn.fs_mount_options/tasks/main.yml
+++ b/ansible/roles/csm.ncn.fs_mount_options/tasks/main.yml
@@ -1,0 +1,33 @@
+# MIT License
+#
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# Use 'defaults' for xfs mount
+- name: Set /var/lib/containers xfs mount options to 'defaults'
+  lineinfile:
+    path: '{{ item }}'
+    state: present
+    line: '\1{{ var_lib_container_mount }}'
+    regexp: '(.*)\[\s?LABEL=CONTAIN.*\]'
+    backrefs: yes
+  loop:
+    - /etc/cloud/cloud.cfg.d/01_metalfs.cfg
+    - /srv/cray/resources/metal/cloud.cfg.d/01_metalfs.cfg

--- a/ansible/vars/csm_packages.yml
+++ b/ansible/vars/csm_packages.yml
@@ -31,6 +31,7 @@ ncn_csm_sles_packages:
   - cray-cmstools-crayctldeploy
   - csm-testing
   - curl
+  - dracut-metal-mdsquash>=2.3.2-1
   - goss-servers
   - hpe-csm-goss-package
   - hpe-csm-scripts


### PR DESCRIPTION
## Summary and Scope

re-adding the XFS mount changes that were removed in https://github.com/Cray-HPE/csm-config/pull/282

## Issues and Related PRs

https://jira-pro.it.hpe.com:8443/browse/MTL-2405

## Risks and Mitigations

none

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable