### PR TITLE
CASMPET-7117: iSCSI SBPS provision and DNS config fails when HSN is not configured/ CASMPET-7126: CFS play for k8s labelling fails when it is already applied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.24.0] - 2024-08-09
+
+### Fixed
+
+- CASMPET-7117: iSCSI SBPS: LIO provision and DNS records config fails when HSN is not configured
+  - fixed iSCSI LIO provisioning to exclude HSN portal config when HSN n/w is not configured
+  - fixed to avoid DNS "SRV" and "A" records creation for HSN when HSN is not configured
+
+- CASMPET-7126: iSCSI SBPS: k8s labelling fails when it is already applied
+  - fixed to avoid applying k8s label when it is already exist
+
 ## [1.23.0] - 2024-08-08
 
 ### Dependencies
@@ -468,7 +479,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ansible playbook for applying csm packages to Compute and Application nodes
 
-[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.23.0...HEAD
+[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.24.0...HEAD
+
+[1.24.0]: https://github.com/Cray-HPE/csm-config/compare/1.23.0...1.24.0
 
 [1.23.0]: https://github.com/Cray-HPE/csm-config/compare/1.22.0...1.23.0
 

--- a/ansible/roles/csm.sbps.apply_label/files/apply_k8s_label.sh
+++ b/ansible/roles/csm.sbps.apply_label/files/apply_k8s_label.sh
@@ -26,4 +26,8 @@
 LABEL="iscsi=sbps"
 HOST_NAME="$(awk '{print $1}' /etc/hostname)"
 
-kubectl label nodes $HOST_NAME $LABEL
+# If the label is already applied to this node, then exit
+kubectl get nodes -l "$LABEL" --no-headers | grep -Eq "^${HOST_NAME}[[:space:]]" && exit 0
+
+# Otherwise, apply the label to the node
+kubectl label nodes "$HOST_NAME" "$LABEL"

--- a/ansible/roles/csm.sbps.dns_srv_records/files/sbps_dns_srv_records.sh
+++ b/ansible/roles/csm.sbps.dns_srv_records/files/sbps_dns_srv_records.sh
@@ -33,39 +33,45 @@ nmn_srv_records=""
 hsn_a_records=""
 nmn_a_records=""
 
-system_name="$(cat /etc/environment | grep SYSTEM_NAME | awk -F= '{print $2;}')"
+eval "$(grep -e SITE_DOMAIN -e SYSTEM_NAME /etc/environment)"
 
-# - read each line from the file "/tmp/hsn_nmn_info.txt" passed on to this script
+# - read each line from the file /tmp/hsn_nmn_info.txt passed on to this script
 #   to fetch Host Name, HSN and NMN IP's for each worker node.
 #   line format is: <Host Name>:<HSN IP>:<NMN IP>
-# - then create DNS "SRV" and "A" records based on the above data
+# - then create DNS SRV and A records based on the above data
 while read -r line; do
-  ncn_worker_node=`echo "$line" | awk -F ":" '{print $1}'`
-  iscsi_server_id="id-$(echo $ncn_worker_node | awk -F "-" '{print $2}' | awk '{print substr($1,2);}')"
-  hsn_ip=`echo "$line" | awk -F ":" '{print $2}'`
-  nmn_ip=`echo "$line" | awk -F ":" '{print $3}'`
+  ncn_worker_node=$(echo "$line" | awk -F ":" '{print $1}')
+  iscsi_server_id="id-$(echo "$ncn_worker_node" | awk -F "-" '{print $2}' | awk '{print substr($1,2);}')"
 
-  hsn_srv_records="$hsn_srv_records{\"content\": \"1 0 3260 iscsi-server-"${iscsi_server_id}.hsn.${system_name}".hpc.amslabs.hpecorp.net.\",\"disabled\": false},"
-  nmn_srv_records="$nmn_srv_records{\"content\": \"1 0 3260 iscsi-server-"${iscsi_server_id}.nmn.${system_name}".hpc.amslabs.hpecorp.net.\",\"disabled\": false},"
-  hsn_a_records="$hsn_a_records{\"comments\": [], \"name\": \"iscsi-server-"${iscsi_server_id}.hsn.${system_name}".hpc.amslabs.hpecorp.net.\",\"changetype\":\"REPLACE\",\"records\":[{\"content\": \"${hsn_ip}\",\"disabled\": false}],\"ttl\": 3600,\"type\": \"A\"},"
-  nmn_a_records="$nmn_a_records{\"comments\": [], \"name\": \"iscsi-server-"${iscsi_server_id}.nmn.${system_name}".hpc.amslabs.hpecorp.net.\",\"changetype\":\"REPLACE\",\"records\":[{\"content\": \"${nmn_ip}\",\"disabled\": false}],\"ttl\": 3600,\"type\": \"A\"},"
+  hsn_ip=$(echo "$line" | awk -F ":" '{print $2}') || true
+  nmn_ip=$(echo "$line" | awk -F ":" '{print $3}')
+
+  if [[ -n $hsn_ip ]]
+  then
+    hsn_srv_records="$hsn_srv_records{\"content\": \"1 0 3260 iscsi-server-"${iscsi_server_id}.hsn.${SYSTEM_NAME}.${SITE_DOMAIN}."\",\"disabled\": false},"
+
+    hsn_a_records="$hsn_a_records{\"comments\": [], \"name\": \"iscsi-server-"${iscsi_server_id}.hsn.${SYSTEM_NAME}.${SITE_DOMAIN}."\",\"changetype\":\"REPLACE\",\"records\":[{\"content\": \"${hsn_ip}\",\"disabled\": false}],\"ttl\": 3600,\"type\": \"A\"},"
+  fi
+
+  nmn_srv_records="$nmn_srv_records{\"content\": \"1 0 3260 iscsi-server-"${iscsi_server_id}.nmn.${SYSTEM_NAME}.${SITE_DOMAIN}."\",\"disabled\": false},"
+
+  nmn_a_records="$nmn_a_records{\"comments\": [], \"name\": \"iscsi-server-"${iscsi_server_id}.nmn.${SYSTEM_NAME}.${SITE_DOMAIN}."\",\"changetype\":\"REPLACE\",\"records\":[{\"content\": \"${nmn_ip}\",\"disabled\": false}],\"ttl\": 3600,\"type\": \"A\"},"
 done
 
-hsn_srv_records=`echo "${hsn_srv_records%?}"`
-nmn_srv_records=`echo "${nmn_srv_records%?}"`
-hsn_a_records=`echo "${hsn_a_records%?}"`
-nmn_a_records=`echo "${nmn_a_records%?}"`
-
+hsn_srv_records="${hsn_srv_records%?}"
+nmn_srv_records="${nmn_srv_records%?}"
+hsn_a_records="${hsn_a_records%?}"
+nmn_a_records="${nmn_a_records%?}"
 
 # PATCH (update) DNS "SRV" records for HSN and NMN for all the worker nodes
-curl -s -X PATCH -H "X-API-Key: ${PDNS_API_KEY}" "http://${PDNS_API}:8081/api/v1/servers/localhost/zones/${system_name}.hpc.amslabs.hpecorp.net" -d'
+curl -s -X PATCH -H "X-API-Key: ${PDNS_API_KEY}" "http://${PDNS_API}:8081/api/v1/servers/localhost/zones/${SYSTEM_NAME}.${SITE_DOMAIN}" -d'
 {
   "rrsets": [
     {
       "comments": [],
-      "name": "_sbps-hsn._tcp.'"${system_name}"'.hpc.amslabs.hpecorp.net.",
-      "changetype": "REPLACE",
-      "records": [
+      "name": "_sbps-hsn._tcp.'"${SYSTEM_NAME}"'.'"${SITE_DOMAIN}."',
+      "changetype":"REPLACE",
+      "records":[
         '"${hsn_srv_records}"'
       ],
       "ttl": 3600,
@@ -73,9 +79,9 @@ curl -s -X PATCH -H "X-API-Key: ${PDNS_API_KEY}" "http://${PDNS_API}:8081/api/v1
     },
     {
       "comments": [],
-      "name": "_sbps-nmn._tcp.'"${system_name}"'.hpc.amslabs.hpecorp.net.",
-      "changetype": "REPLACE",
-      "records": [
+      "name": "_sbps-nmn._tcp.'"${SYSTEM_NAME}"'.'"${SITE_DOMAIN}."',
+      "changetype":"REPLACE",
+      "records":[
         '"${nmn_srv_records}"'
       ],
       "ttl": 3600,
@@ -84,16 +90,19 @@ curl -s -X PATCH -H "X-API-Key: ${PDNS_API_KEY}" "http://${PDNS_API}:8081/api/v1
   ]
 }'
 
-# PATCH (update) DNS  "A" records for HSN for all the worker nodes
-curl -s -X PATCH -H "X-API-Key: ${PDNS_API_KEY}" "http://${PDNS_API}:8081/api/v1/servers/localhost/zones/hsn.${system_name}.hpc.amslabs.hpecorp.net" -d'
-{
-  "rrsets": [
-    '"${hsn_a_records}"'
-  ]
-}'
+if [[ -n $hsn_a_records ]]
+then
+  # PATCH (update) DNS  "A" records for HSN for all the worker nodes
+  curl -s -X PATCH -H "X-API-Key: ${PDNS_API_KEY}" "http://${PDNS_API}:8081/api/v1/servers/localhost/zones/hsn.${SYSTEM_NAME}.${SITE_DOMAIN}" -d'
+  {
+    "rrsets": [
+      '"${hsn_a_records}"'
+    ]
+  }'
+fi
 
 # PATCH (update) DNS  "A" records for NMN for all the worker nodes
-curl -s -X PATCH -H "X-API-Key: ${PDNS_API_KEY}" "http://${PDNS_API}:8081/api/v1/servers/localhost/zones/nmn.${system_name}.hpc.amslabs.hpecorp.net" -d'
+curl -s -X PATCH -H "X-API-Key: ${PDNS_API_KEY}" "http://${PDNS_API}:8081/api/v1/servers/localhost/zones/nmn.${SYSTEM_NAME}.${SITE_DOMAIN}" -d'
 {
   "rrsets": [
     '"${nmn_a_records}"'

--- a/ansible/roles/csm.sbps.dns_srv_records/files/sbps_get_host_hsn_nmn.sh
+++ b/ansible/roles/csm.sbps.dns_srv_records/files/sbps_get_host_hsn_nmn.sh
@@ -27,8 +27,15 @@ set -euo pipefail
 
 # Get Host Name, HSN IP and NMN IP of worker node
 host_name="$(awk '{print $1}' /etc/hostname)"
-hsn_ip="$(ip addr | grep "hsn0$" | awk '{print $2;}' | awk -F\/ '{print $1;}')"
-nmn_ip="$(ip addr | grep "nmn0$" | awk '{print $2;}' | awk -F\/ '{print $1;}')"
+
+hsn_ip="$(ip addr | grep "hsn0$" | awk '{print $2;}')" || true
+
+if [[ -n $hsn_ip ]]
+then
+  hsn_ip="$(echo "$hsn_ip" | awk -F/ '{print $1;}')"
+fi
+
+nmn_ip="$(ip addr | grep "nmn0$" | awk '{print $2;}' | awk -F/ '{print $1;}')"
 
 # echo the details to stdout to be picked by next task in the playbook
 echo "$host_name:$hsn_ip:$nmn_ip"


### PR DESCRIPTION
## Summary and Scope

- CASMPET-7117: iSCSI SBPS: LIO provision and DNS records config fails when HSN is not configured
  - fixed iSCSI LIO provisioning to exclude HSN portal config when HSN n/w is not configured
  - fixed to avoid DNS "SRV" and "A" records creation for HSN when HSN is not configured

- CASMPET-7126: iSCSI SBPS: k8s labelling fails when it is already applied
  - fixed to avoid applying k8s label when it already exists

## Issues and Related PRs

Original EPIC: https://jira-pro.it.hpe.com:8443/browse/CASMPET-6797

## Testing

Tested on bare metal systems with multi worker nodes

### Tested on:

"starlord" and "Odin"

### Test description:
- verified LIO provisioning where HSN n/w is not configured, where it does not fail the overall config instead ignores HSN and creates rest of the portals (NMN and CMN).
- verified LIO provisioning where HSN n/w is configured, it creates all three n/w portals HSN, NMN and CMN.
- verified DNS "SRV" and "A" records creation where HSN n/w is not configured, it creates “SRV” and “A” records for NMN without any failure.
- verified DNS "SRV" and "A" records creation where HSN n/w is configured, it creates “SRV” and “A” records for both HSN and NMN without any failure.
- verified k8s node labelling fresh and also when it is already applied. K8s node labelling is successful without any failure in both cases.


- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

None

## Pull Request Checklist

- [] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

