### PR TITLE
Feature/casmpet 7175

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.23.0] - 2024-07-11
+
+### Fixed
+
+- CASMPET-7117: iSCSI SBPS: LIO provision and DNS records config fails when HSN is not configured
+  - fixed iSCSI LIO provisioning to exclude HSN portal config when HSN n/w is not configured
+  - fixed to avoid DNS "SRV" and "A" records creation for HSN when HSN is not configured
+
+- CASMPET-7126: iSCSI SBPS: k8s labelling fails when it is already applied
+  - fixed to avoid applying k8s label when it is already exist
+
 ## [1.22.0] - 2024-06-25
 
 ### Added
@@ -462,7 +473,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ansible playbook for applying csm packages to Compute and Application nodes
 
-[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.22.0...HEAD
+[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.23.0...HEAD
+
+[1.23.0]: https://github.com/Cray-HPE/csm-config/compare/1.22.0...1.23.0
 
 [1.22.0]: https://github.com/Cray-HPE/csm-config/compare/1.21.0...1.22.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.24.0] - 2024-08-03
+
+### Fixed
+
+- CASMPET-7175: iSCSI SBPS: radosgw-admin cmd fails with "auth: unable to find a keyring..."
+  part of s3fs mount for boot images (boot-images bucket)
+      - fixed CFS play to create s3 access/ secret key on master node followed by mounting
+        s3 boot images with this s3 key on worker nodes.
+
 ## [1.23.0] - 2024-07-11
 
 ### Fixed
@@ -473,7 +482,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ansible playbook for applying csm packages to Compute and Application nodes
 
-[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.23.0...HEAD
+[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.24.0...HEAD
+
+[1.24.0]: https://github.com/Cray-HPE/csm-config/compare/1.23.0...1.24.0
 
 [1.23.0]: https://github.com/Cray-HPE/csm-config/compare/1.22.0...1.23.0
 

--- a/ansible/config_sbps_iscsi_targets.yml
+++ b/ansible/config_sbps_iscsi_targets.yml
@@ -42,4 +42,4 @@
     # Configure SBPS DNS "SRV" and "A" records
     - role: csm.sbps.dns_srv_records
     # Mount s3 bucket 'boot-images' using s3fs read-only policy for SBPS agent
-    #- role: csm.sbps.mount_s3_images
+    - role: csm.sbps.mount_s3_images

--- a/ansible/config_sbps_iscsi_targets.yml
+++ b/ansible/config_sbps_iscsi_targets.yml
@@ -42,4 +42,4 @@
     # Configure SBPS DNS "SRV" and "A" records
     - role: csm.sbps.dns_srv_records
     # Mount s3 bucket 'boot-images' using s3fs read-only policy for SBPS agent
-    - role: csm.sbps.mount_s3_images
+    #- role: csm.sbps.mount_s3_images

--- a/ansible/roles/csm.sbps.apply_label/files/apply_k8s_label.sh
+++ b/ansible/roles/csm.sbps.apply_label/files/apply_k8s_label.sh
@@ -26,8 +26,7 @@
 LABEL="iscsi=sbps"
 HOST_NAME="$(awk '{print $1}' /etc/hostname)"
 
-
-if [[ ! $(kubectl get nodes -l $LABEL | grep $HOST_NAME) ]]
+if [[ ! $(kubectl get nodes -l $LABEL | grep "$HOST_NAME") ]]
 then
-  kubectl label nodes $HOST_NAME $LABEL
+  kubectl label nodes "$HOST_NAME" $LABEL
 fi

--- a/ansible/roles/csm.sbps.apply_label/files/apply_k8s_label.sh
+++ b/ansible/roles/csm.sbps.apply_label/files/apply_k8s_label.sh
@@ -26,9 +26,8 @@
 LABEL="iscsi=sbps"
 HOST_NAME="$(awk '{print $1}' /etc/hostname)"
 
-label_is_present=`kubectl get nodes --show-labels=true $HOST_NAME | grep $LABEL`
 
-if [[ -z $label_is_present ]]
+if [[ ! $(kubectl get nodes  -l $LABEL | grep $HOST_NAME) ]]
 then
   kubectl label nodes $HOST_NAME $LABEL
 fi

--- a/ansible/roles/csm.sbps.apply_label/files/apply_k8s_label.sh
+++ b/ansible/roles/csm.sbps.apply_label/files/apply_k8s_label.sh
@@ -27,7 +27,7 @@ LABEL="iscsi=sbps"
 HOST_NAME="$(awk '{print $1}' /etc/hostname)"
 
 
-if [[ ! $(kubectl get nodes  -l $LABEL | grep $HOST_NAME) ]]
+if [[ ! $(kubectl get nodes -l $LABEL | grep $HOST_NAME) ]]
 then
   kubectl label nodes $HOST_NAME $LABEL
 fi

--- a/ansible/roles/csm.sbps.apply_label/files/apply_k8s_label.sh
+++ b/ansible/roles/csm.sbps.apply_label/files/apply_k8s_label.sh
@@ -26,4 +26,9 @@
 LABEL="iscsi=sbps"
 HOST_NAME="$(awk '{print $1}' /etc/hostname)"
 
-kubectl label nodes $HOST_NAME $LABEL
+label_is_present=`kubectl get nodes --show-labels=true $HOST_NAME | grep $LABEL`
+
+if [[ -z $label_is_present ]]
+then
+  kubectl label nodes $HOST_NAME $LABEL
+fi

--- a/ansible/roles/csm.sbps.dns_srv_records/files/sbps_dns_srv_records.sh
+++ b/ansible/roles/csm.sbps.dns_srv_records/files/sbps_dns_srv_records.sh
@@ -46,14 +46,14 @@ while read -r line; do
   hsn_ip=`echo "$line" | awk -F ":" '{print $2}'` || true
   nmn_ip=`echo "$line" | awk -F ":" '{print $3}'`
 
-  if [[ ! -z $hsn_ip ]]
+  if [[ -n $hsn_ip ]]
   then
-    hsn_srv_records="$hsn_srv_records{\"comments\": [], \"name\": \"_sbps-hsn._tcp."${system_name}".hpc.amslabs.hpecorp.net.\",\"changetype\":\"REPLACE\",\"records\":[{\"content\": \"1 0 3260 iscsi-server-"${iscsi_server_id}.hsn.${system_name}".hpc.amslabs.hpecorp.net.\",\"disabled\": false}],\"ttl\": 3600,\"type\": \"SRV\"},"
+    hsn_srv_records="$hsn_srv_records{\"content\": \"1 0 3260 iscsi-server-"${iscsi_server_id}.hsn.${system_name}".hpc.amslabs.hpecorp.net.\",\"disabled\": false},"
 
     hsn_a_records="$hsn_a_records{\"comments\": [], \"name\": \"iscsi-server-"${iscsi_server_id}.hsn.${system_name}".hpc.amslabs.hpecorp.net.\",\"changetype\":\"REPLACE\",\"records\":[{\"content\": \"${hsn_ip}\",\"disabled\": false}],\"ttl\": 3600,\"type\": \"A\"},"
   fi
 
-  nmn_srv_records="$nmn_srv_records{\"comments\": [], \"name\": \"_sbps-nmn._tcp."${system_name}".hpc.amslabs.hpecorp.net.\",\"changetype\":\"REPLACE\",\"records\":[{\"content\": \"1 0 3260 iscsi-server-"${iscsi_server_id}.nmn.${system_name}".hpc.amslabs.hpecorp.net.\",\"disabled\": false}],\"ttl\": 3600,\"type\": \"SRV\"},"
+  nmn_srv_records="$nmn_srv_records{\"content\": \"1 0 3260 iscsi-server-"${iscsi_server_id}.nmn.${system_name}".hpc.amslabs.hpecorp.net.\",\"disabled\": false},"
 
   nmn_a_records="$nmn_a_records{\"comments\": [], \"name\": \"iscsi-server-"${iscsi_server_id}.nmn.${system_name}".hpc.amslabs.hpecorp.net.\",\"changetype\":\"REPLACE\",\"records\":[{\"content\": \"${nmn_ip}\",\"disabled\": false}],\"ttl\": 3600,\"type\": \"A\"},"
 done
@@ -63,17 +63,35 @@ nmn_srv_records=`echo "${nmn_srv_records%?}"`
 hsn_a_records=`echo "${hsn_a_records%?}"`
 nmn_a_records=`echo "${nmn_a_records%?}"`
 
+
 # PATCH (update) DNS "SRV" records for HSN and NMN for all the worker nodes
 curl -s -X PATCH -H "X-API-Key: ${PDNS_API_KEY}" "http://${PDNS_API}:8081/api/v1/servers/localhost/zones/${system_name}.hpc.amslabs.hpecorp.net" -d'
 {
   "rrsets": [
-    '"${hsn_srv_records}"'
-
-    '"${nmn_srv_records}"'
+    {
+      "comments": [],
+      "name": "_sbps-hsn._tcp.'"${system_name}"'.hpc.amslabs.hpecorp.net.",
+      "changetype":"REPLACE",
+      "records":[
+        '"${hsn_srv_records}"'
+      ],
+      "ttl": 3600,
+      "type": "SRV"
+    },
+    {
+      "comments": [],
+      "name": "_sbps-nmn._tcp.'"${system_name}"'.hpc.amslabs.hpecorp.net.",
+      "changetype":"REPLACE",
+      "records":[
+        '"${nmn_srv_records}"'
+      ],
+      "ttl": 3600,
+      "type": "SRV"
+    }
   ]
 }'
 
-if [[ ! -z $hsn_a_records ]]
+if [[ -n $hsn_a_records ]]
 then
   # PATCH (update) DNS  "A" records for HSN for all the worker nodes
   curl -s -X PATCH -H "X-API-Key: ${PDNS_API_KEY}" "http://${PDNS_API}:8081/api/v1/servers/localhost/zones/hsn.${system_name}.hpc.amslabs.hpecorp.net" -d'

--- a/ansible/roles/csm.sbps.dns_srv_records/files/sbps_get_host_hsn_nmn.sh
+++ b/ansible/roles/csm.sbps.dns_srv_records/files/sbps_get_host_hsn_nmn.sh
@@ -27,7 +27,14 @@ set -euo pipefail
 
 # Get Host Name, HSN IP and NMN IP of worker node
 host_name="$(awk '{print $1}' /etc/hostname)"
-hsn_ip="$(ip addr | grep "hsn0$" | awk '{print $2;}' | awk -F\/ '{print $1;}')"
+
+hsn_ip="$(ip addr | grep "hsn0$" | awk '{print $2;}')" || true
+
+if [[ ! -z $hsn_ip ]]
+then
+  hsn_ip="$(echo $hsn_ip | awk -F\/ '{print $1;}')"
+fi
+
 nmn_ip="$(ip addr | grep "nmn0$" | awk '{print $2;}' | awk -F\/ '{print $1;}')"
 
 # echo the details to stdout to be picked by next task in the playbook

--- a/ansible/roles/csm.sbps.dns_srv_records/files/sbps_get_host_hsn_nmn.sh
+++ b/ansible/roles/csm.sbps.dns_srv_records/files/sbps_get_host_hsn_nmn.sh
@@ -32,10 +32,10 @@ hsn_ip="$(ip addr | grep "hsn0$" | awk '{print $2;}')" || true
 
 if [[ -n $hsn_ip ]]
 then
-  hsn_ip="$(echo $hsn_ip | awk -F\/ '{print $1;}')"
+  hsn_ip="$(echo "$hsn_ip" | awk -F/ '{print $1;}')"
 fi
 
-nmn_ip="$(ip addr | grep "nmn0$" | awk '{print $2;}' | awk -F\/ '{print $1;}')"
+nmn_ip="$(ip addr | grep "nmn0$" | awk '{print $2;}' | awk -F/ '{print $1;}')"
 
 # echo the details to stdout to be picked by next task in the playbook
 echo "$host_name:$hsn_ip:$nmn_ip"

--- a/ansible/roles/csm.sbps.dns_srv_records/files/sbps_get_host_hsn_nmn.sh
+++ b/ansible/roles/csm.sbps.dns_srv_records/files/sbps_get_host_hsn_nmn.sh
@@ -30,7 +30,7 @@ host_name="$(awk '{print $1}' /etc/hostname)"
 
 hsn_ip="$(ip addr | grep "hsn0$" | awk '{print $2;}')" || true
 
-if [[ ! -z $hsn_ip ]]
+if [[ -n $hsn_ip ]]
 then
   hsn_ip="$(echo $hsn_ip | awk -F\/ '{print $1;}')"
 fi

--- a/ansible/roles/csm.sbps.lio_config/files/provision_iscsi_server.sh
+++ b/ansible/roles/csm.sbps.lio_config/files/provision_iscsi_server.sh
@@ -39,16 +39,13 @@ function save_server_config()
 
 function add_server_target()
 {
-        TARGET_SERVER_IQN="${IQN_PREFIX}$1"
-        NMN_IP="$2"
-        CMN_IP="$3"
+        TARGET_SERVER_IQN="${IQN_PREFIX}${HOST}"
         targetcli "/iscsi create $TARGET_SERVER_IQN" &> /dev/null
         targetcli "/iscsi/${TARGET_SERVER_IQN}/tpg1/portals delete ip_address=0.0.0.0 ip_port=3260" &> /dev/null
         targetcli "/iscsi/${TARGET_SERVER_IQN}/tpg1/portals create ${NMN_IP}" &> /dev/null
 
-        if [[ ! -z $HSN_IP ]]
+        if [[ -n $HSN_IP ]]
         then
-          HSN_IP="$4"
           targetcli "/iscsi/${TARGET_SERVER_IQN}/tpg1/portals create ${HSN_IP}" &> /dev/null
         fi
 
@@ -70,7 +67,7 @@ function auto_generate_node_acls()
 
 HSN_IP="$(ip addr | grep "hsn0$")" || true
 
-if [[ ! -z $HSN_IP ]]
+if [[ -n $HSN_IP ]]
 then
   HSN_IP="$(echo $HSN_IP | awk '{print $2;}' | awk -F\/ '{print $1;}')"
 fi
@@ -81,7 +78,7 @@ CMN_IP="$(host -4 ${HOST}.cmn | awk '{print $NF;}')"
 service target stop
 service target start
 clear_server_config
-SERVER_IQN="$(add_server_target $HOST $NMN_IP $CMN_IP $HSN_IP)"
+SERVER_IQN="$(add_server_target)"
 
 #--------------------------------------------------------------------
 # Configure automatic intiator mappings when they attempt to connect

--- a/ansible/roles/csm.sbps.lio_config/files/provision_iscsi_server.sh
+++ b/ansible/roles/csm.sbps.lio_config/files/provision_iscsi_server.sh
@@ -41,12 +41,17 @@ function add_server_target()
 {
         TARGET_SERVER_IQN="${IQN_PREFIX}$1"
         NMN_IP="$2"
-        HSN_IP="$3"
-        CMN_IP="$4"
+        CMN_IP="$3"
         targetcli "/iscsi create $TARGET_SERVER_IQN" &> /dev/null
         targetcli "/iscsi/${TARGET_SERVER_IQN}/tpg1/portals delete ip_address=0.0.0.0 ip_port=3260" &> /dev/null
         targetcli "/iscsi/${TARGET_SERVER_IQN}/tpg1/portals create ${NMN_IP}" &> /dev/null
-        targetcli "/iscsi/${TARGET_SERVER_IQN}/tpg1/portals create ${HSN_IP}" &> /dev/null
+
+        if [[ ! -z $HSN_IP ]]
+        then
+          HSN_IP="$4"
+          targetcli "/iscsi/${TARGET_SERVER_IQN}/tpg1/portals create ${HSN_IP}" &> /dev/null
+        fi
+
         targetcli "/iscsi/${TARGET_SERVER_IQN}/tpg1/portals create ${CMN_IP}" &> /dev/null
         targetcli "/iscsi/${TARGET_SERVER_IQN}/tpg1 set attribute demo_mode_write_protect=1" &> /dev/null
         targetcli "/iscsi/${TARGET_SERVER_IQN}/tpg1 set attribute prod_mode_write_protect=1" &> /dev/null
@@ -63,14 +68,20 @@ function auto_generate_node_acls()
 # Base Target Configuration
 #--------------------------------------------------------------------
 
+HSN_IP="$(ip addr | grep "hsn0$")" || true
+
+if [[ ! -z $HSN_IP ]]
+then
+  HSN_IP="$(echo $HSN_IP | awk '{print $2;}' | awk -F\/ '{print $1;}')"
+fi
+
 NMN_IP="$(host -4 ${HOST}.nmn | awk '{print $NF;}')"
-HSN_IP="$(ip addr | grep "hsn0$" | awk '{print $2;}' | awk -F\/ '{print $1;}')"
 CMN_IP="$(host -4 ${HOST}.cmn | awk '{print $NF;}')"
 
 service target stop
 service target start
 clear_server_config
-SERVER_IQN="$(add_server_target $HOST $NMN_IP $HSN_IP $CMN_IP)"
+SERVER_IQN="$(add_server_target $HOST $NMN_IP $CMN_IP $HSN_IP)"
 
 #--------------------------------------------------------------------
 # Configure automatic intiator mappings when they attempt to connect

--- a/ansible/roles/csm.sbps.lio_config/files/provision_iscsi_server.sh
+++ b/ansible/roles/csm.sbps.lio_config/files/provision_iscsi_server.sh
@@ -52,7 +52,7 @@ function add_server_target()
         targetcli "/iscsi/${TARGET_SERVER_IQN}/tpg1/portals create ${CMN_IP}" &> /dev/null
         targetcli "/iscsi/${TARGET_SERVER_IQN}/tpg1 set attribute demo_mode_write_protect=1" &> /dev/null
         targetcli "/iscsi/${TARGET_SERVER_IQN}/tpg1 set attribute prod_mode_write_protect=1" &> /dev/null
-        echo $TARGET_SERVER_IQN
+        echo "$TARGET_SERVER_IQN"
 }
 
 function auto_generate_node_acls()
@@ -69,11 +69,11 @@ HSN_IP="$(ip addr | grep "hsn0$")" || true
 
 if [[ -n $HSN_IP ]]
 then
-  HSN_IP="$(echo $HSN_IP | awk '{print $2;}' | awk -F\/ '{print $1;}')"
+  HSN_IP="$(echo "$HSN_IP" | awk '{print $2;}' | awk -F/ '{print $1;}')"
 fi
 
-NMN_IP="$(host -4 ${HOST}.nmn | awk '{print $NF;}')"
-CMN_IP="$(host -4 ${HOST}.cmn | awk '{print $NF;}')"
+NMN_IP="$(host -4 "${HOST}.nmn" | awk '{print $NF;}')"
+CMN_IP="$(host -4 "${HOST}.cmn" | awk '{print $NF;}')"
 
 service target stop
 service target start
@@ -84,5 +84,5 @@ SERVER_IQN="$(add_server_target)"
 # Configure automatic intiator mappings when they attempt to connect
 #--------------------------------------------------------------------
 
-auto_generate_node_acls $SERVER_IQN
+auto_generate_node_acls "$SERVER_IQN"
 save_server_config

--- a/ansible/roles/csm.sbps.mount_s3_images/files/create_s3_acess_secret_key.sh
+++ b/ansible/roles/csm.sbps.mount_s3_images/files/create_s3_acess_secret_key.sh
@@ -25,14 +25,10 @@
 
 set -euo pipefail
 
-# Mount s3 boot images (boot-images bucket) with
-# new s3 user (ISCSI-SBPS) read only policy.
-s3_bucket=boot-images
-s3fs_mount_dir=/var/lib/cps-local/boot-images
-filename=.iscsi-sbps.s3fs
-passwd_file="${HOME}/${filename}"
+# Generate s3 key with s3 access key id and secret key
+s3_user=ISCSI-SBPS
+s3_key=$(radosgw-admin user info --uid "${s3_user}" |jq -r '.keys[]|.access_key +":"+ .secret_key')
 
-chmod 600 "${passwd_file}"
-mkdir -pv "${s3fs_mount_dir}"
+# echo s3 key to stdout to be picked by next task in the playbook
+echo "$s3_key"
 
-s3fs "${s3_bucket}" "${s3fs_mount_dir}" -o "passwd_file=${passwd_file},url=http://rgw-vip.nmn,use_path_request_style" -o nonempty

--- a/ansible/roles/csm.sbps.mount_s3_images/tasks/main.yml
+++ b/ansible/roles/csm.sbps.mount_s3_images/tasks/main.yml
@@ -23,9 +23,27 @@
 #
 ---
 
-#  Clear LIO configuration and save 
-#  Set LIO IQN (and default TGT1)
-#  Delete LIO default portal
+#  mount s3 boot images (boot-images bucket)
+#  with new s3 user read only policy using new
+#  s3 access/ secret key.
+
+# Create s3 access/ secret key file for s3 user (ISCSI-SBPS) on master node
+- name: create_s3_acess_secret_key
+  script: "create_s3_acess_secret_key.sh"
+  register: create_s3_acess_secret_key
+  changed_when: create_s3_acess_secret_key.rc == 0
+  delegate_to: localhost
+
+# Create/ update s3 key file (with s3 access key id + s3 secret key) on each worker node
+- name: Update s3 key file on each worker node
+  lineinfile:
+    path: "/root/.iscsi-sbps.s3fs"
+    line: "{{ create_s3_acess_secret_key.stdout | trim }}"
+    state: present
+    create: yes
+
+# mount s3 boot images (boot-images bucket) with
+# new s3 user read only policy on worker nodes
 - name: mount_s3_boot_images
   script: "mount_s3_boot_images.sh"
   register: mount_s3_boot_images


### PR DESCRIPTION
## Summary and Scope
 CASMPET-7175: iSCSI SBPS: radosgw-admin cmd fails with "auth: unable to find a keyring..." part of s3fs mount for "boot-images"
      - "radosgw-admin cmd..." is supposed to be issued on master node to generate s3 access/ secret key and not on worker 
         nodes. Fixed CFS play to create s3 access/ secret key on master node followed by mounting s3 boot images 
         on all worker nodes using this s3 key.

## Issues and Related PRs

[_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._]

Need to merge the PR "https://github.com/Cray-HPE/csm-config/pull/284" first before merging this PR to delelop branch.

## Testing

Tested worker nodes personalization on bare metal system: starlord with CSM 1.6.0-alpha.55 bits

### Tested on:

_starlord_

### Test description:

Tested iSCSI SBPS CFS plays (worker node personalization) on starlord with CSM 1.6. Observed that _radosgw-admin_ command for s3 access/ secret key generation on master node followed by mounting s3 boot images using s3fs command on worker nodes is successful.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

None

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

