### PR TITLE
CASMCMS-9082: Build Docker image on SLE15 SP6 (up from SP4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Dependencies
+
+- CASMCMS-9082: Build Docker image on SLE15 SP6 (up from SP4)
+
 ## [1.22.0] - 2024-06-25
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,10 +23,10 @@
 #
 # Dockerfile for importing CSM content into gitea, to be used with CFS
 
-FROM artifactory.algol60.net/registry.suse.com/suse/sle15:15.4 as product-content-base
+FROM artifactory.algol60.net/registry.suse.com/suse/sle15:15.6 as product-content-base
 WORKDIR /
 
-ARG SP=4
+ARG SP=6
 ARG ARCH=x86_64
 
 # Pin the version of csm-ssh-keys being installed. The actual version is substituted by

--- a/zypper-docker-build.sh
+++ b/zypper-docker-build.sh
@@ -69,7 +69,12 @@ for MODULE in Basesystem Certifications Containers Desktop-Applications Developm
 do
     add_zypper_repos "Module-${MODULE}"
 done
-for PRODUCT in HA HPC SLED SLES SLES_SAP WE; do
+PRODUCTS="HA SLED SLES SLES_SAP WE"
+if [[ ${SP} -lt 6 ]]; then
+    # HPC is deprecated in SP6, but we want to include it for previous SPs
+    PRODUCTS="${PRODUCTS} HPC"
+fi
+for PRODUCT in $PRODUCTS; do
     add_zypper_repos "Product-${PRODUCT}"
 done
 zypper --non-interactive ar --no-gpgcheck "${CSM_SLES_REPO_URL}" csm-sles


### PR DESCRIPTION
This will correct build failures we are currently seeing (related to the SLES mirrors on artifactory), but it's probably something we should do anyway, and CSM 1.6 is as good a time as any.