### PR TITLE
- CASMPET-7175: iSCSI SBPS: radosgw-admin cmd fails with "auth: unabl…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.25.0] - 2024-08-12
+
+### Fixed
+
+- CASMPET-7175: iSCSI SBPS: radosgw-admin cmd fails with "auth: unable to find a keyring..."
+  part of s3fs mount for boot images (boot-images bucket)
+      - fixed CFS play to create s3 access/ secret key on master node followed by mounting
+        s3 boot images with this s3 key on worker nodes.
+
 ## [1.24.0] - 2024-08-09
 
 ### Fixed
@@ -479,7 +488,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ansible playbook for applying csm packages to Compute and Application nodes
 
-[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.24.0...HEAD
+[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.25.0...HEAD
+
+[1.25.0]: https://github.com/Cray-HPE/csm-config/compare/1.24.0...1.25.0
 
 [1.24.0]: https://github.com/Cray-HPE/csm-config/compare/1.23.0...1.24.0
 

--- a/ansible/roles/csm.sbps.mount_s3_images/files/create_s3_acess_secret_key.sh
+++ b/ansible/roles/csm.sbps.mount_s3_images/files/create_s3_acess_secret_key.sh
@@ -25,14 +25,10 @@
 
 set -euo pipefail
 
-# Mount s3 boot images (boot-images bucket) with
-# new s3 user (ISCSI-SBPS) read only policy.
-s3_bucket=boot-images
-s3fs_mount_dir=/var/lib/cps-local/boot-images
-filename=.iscsi-sbps.s3fs
-passwd_file="${HOME}/${filename}"
+# Generate s3 key with s3 access key id and secret key
+s3_user=ISCSI-SBPS
+s3_key=$(radosgw-admin user info --uid "${s3_user}" |jq -r '.keys[]|.access_key +":"+ .secret_key')
 
-chmod 600 "${passwd_file}"
-mkdir -pv "${s3fs_mount_dir}"
+# echo s3 key to stdout to be picked by next task in the playbook
+echo "$s3_key"
 
-s3fs "${s3_bucket}" "${s3fs_mount_dir}" -o "passwd_file=${passwd_file},url=http://rgw-vip.nmn,use_path_request_style" -o nonempty

--- a/ansible/roles/csm.sbps.mount_s3_images/tasks/main.yml
+++ b/ansible/roles/csm.sbps.mount_s3_images/tasks/main.yml
@@ -23,9 +23,27 @@
 #
 ---
 
-#  Clear LIO configuration and save 
-#  Set LIO IQN (and default TGT1)
-#  Delete LIO default portal
+#  mount s3 boot images (boot-images bucket)
+#  with new s3 user read only policy using new
+#  s3 access/ secret key.
+
+# Create s3 access/ secret key file for s3 user (ISCSI-SBPS) on master node
+- name: create_s3_acess_secret_key
+  script: "create_s3_acess_secret_key.sh"
+  register: create_s3_acess_secret_key
+  changed_when: create_s3_acess_secret_key.rc == 0
+  delegate_to: localhost
+
+# Create/ update s3 key file (with s3 access key id + s3 secret key) on each worker node
+- name: Update s3 key file on each worker node
+  lineinfile:
+    path: "/root/.iscsi-sbps.s3fs"
+    line: "{{ create_s3_acess_secret_key.stdout | trim }}"
+    state: present
+    create: yes
+
+# mount s3 boot images (boot-images bucket) with
+# new s3 user read only policy on worker nodes
 - name: mount_s3_boot_images
   script: "mount_s3_boot_images.sh"
   register: mount_s3_boot_images


### PR DESCRIPTION
## Summary and Scope
 CASMPET-7175: iSCSI SBPS: radosgw-admin cmd fails with "auth: unable to find a keyring..." part of s3fs mount for "boot-images"
      - "radosgw-admin cmd..." is supposed to be issued on master node to generate s3 access/ secret key and not on 
          worker nodes. Fixed CFS play to create s3 access/ secret key on master node followed by mounting s3 boot images 
         on all worker nodes using this s3 key.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

Tested worker nodes personalization on bare metal system: starlord with CSM 1.6.0-alpha.55 bits

### Tested on:

baremetal system: starlord

### Test description:

Tested iSCSI SBPS CFS plays (worker node personalization) on starlord with CSM 1.6. Observed that _radosgw-admin_ command for s3 access/ secret key generation on master node followed by mounting s3 boot images using s3fs command on worker nodes is successful.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable **(NA)**
- [x] Copyrights updated
- [x] License file intact **(NA)**
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable **(NA)**

