### PR TITLE
- CASMPET-7180: New CFS play for enabling spire for SBPS Marshal Agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.24.2] - 2024-08-23
+
+### Added 
+
+- CASMPET-7180: New CFS play to enable spire for SBPS Marshal Agent
+- CASMPET-7195: New CFS play to install (+ previous enable) SBPS Marshal Agent
+
+### Fixed
+- typo fix in DNS SRV A records
+
 ## [1.24.1] - 2024-08-12
 
 ### Fixed
@@ -488,7 +498,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ansible playbook for applying csm packages to Compute and Application nodes
 
-[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.24.1...HEAD
+[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.24.2...HEAD
+
+[1.24.2]: https://github.com/Cray-HPE/csm-config/compare/1.24.1...1.24.2
 
 [1.24.1]: https://github.com/Cray-HPE/csm-config/compare/1.24.0...1.24.1
 

--- a/ansible/config_sbps_iscsi_targets.yml
+++ b/ansible/config_sbps_iscsi_targets.yml
@@ -23,11 +23,19 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
-# Configure "Management_Worker" (all worker nodes) by default OR
-# configure only subset of worker nodes("Management_Worker") defined in 
-# CFS config/ HSM group, set by user/ admin during node personalization.
 #
-# Install and configure SBPS on iSCSI targets (worker NCNs)
+# Personalize/ configure identified worker nodes for iSCSI SBPS (Scalable Boot
+# Content Projection Service):
+#   - provision these worker nodes as iSCSI targets with LIO services
+#   - install/ enable SBPS Marshal Agent(systemd service) on these iSCSI targets
+#   - create DNS SRV and A records to be used to discover iSCSI targets during compute nodes booting
+#   - mount s3 bucket (boot-image) images using new dedicated s3 read only policy
+#   - apply k8s label to the personalized nodes for other consumers of iSCSI SBPS
+# 
+# By default all the worker nodes (Management_Worker) will be configured OR 
+# admin/ user can chose to configure only subset of worker nodes defined in 
+# CFS config/ HSM group during personalization.
+#
 - hosts: Management_Worker
   gather_facts: no
   any_errors_fatal: true
@@ -35,9 +43,11 @@
   roles:
     # Apply k8s label on all the intended worker nodes
     - role: csm.sbps.apply_label
-    # Enable/ start SBPS Marshal Agent (systemd service)
-    - role: csm.sbps.enable_sbps_marshal
-    # Configure SBPS
+    # Enable spire for SBPS Marshal Agent (systemd service)
+    - role: csm.sbps.enable_spire
+    # Install and enable SBPS Marshal Agent
+    - role: csm.sbps.install_enable_marshal
+    # Provision iSCSI targets/ LIO services
     - role: csm.sbps.lio_config
     # Configure SBPS DNS "SRV" and "A" records
     - role: csm.sbps.dns_srv_records

--- a/ansible/roles/csm.gpg_keys/tasks/main.yml
+++ b/ansible/roles/csm.gpg_keys/tasks/main.yml
@@ -23,7 +23,7 @@
 #
 # Tasks for the csm.gpg_keys role
 - name: Fetch Public GPG Keys from the K8S secret
-# no_log: true
+  no_log: true
   local_action:
     module: csm_read_secret
     name: "{{ csm_gpg_key_k8s_secret }}"

--- a/ansible/roles/csm.sbps.dns_srv_records/files/sbps_dns_srv_records.sh
+++ b/ansible/roles/csm.sbps.dns_srv_records/files/sbps_dns_srv_records.sh
@@ -69,7 +69,7 @@ curl -s -X PATCH -H "X-API-Key: ${PDNS_API_KEY}" "http://${PDNS_API}:8081/api/v1
   "rrsets": [
     {
       "comments": [],
-      "name": "_sbps-hsn._tcp.'"${SYSTEM_NAME}"'.'"${SITE_DOMAIN}."',
+      "name": "_sbps-hsn._tcp.'"${SYSTEM_NAME}"'.'"${SITE_DOMAIN}."'",
       "changetype":"REPLACE",
       "records":[
         '"${hsn_srv_records}"'
@@ -79,7 +79,7 @@ curl -s -X PATCH -H "X-API-Key: ${PDNS_API_KEY}" "http://${PDNS_API}:8081/api/v1
     },
     {
       "comments": [],
-      "name": "_sbps-nmn._tcp.'"${SYSTEM_NAME}"'.'"${SITE_DOMAIN}."',
+      "name": "_sbps-nmn._tcp.'"${SYSTEM_NAME}"'.'"${SITE_DOMAIN}."'",
       "changetype":"REPLACE",
       "records":[
         '"${nmn_srv_records}"'

--- a/ansible/roles/csm.sbps.enable_spire/README.md
+++ b/ansible/roles/csm.sbps.enable_spire/README.md
@@ -1,0 +1,37 @@
+csm.sbps.enable_spire
+=====================
+
+Enable spire for SBPS Marshal Agent on specified NCN worker nodes.
+
+Requirements
+------------
+
+None.
+
+Role Variables
+--------------
+
+Dependencies
+------------
+
+Example Playbook
+----------------
+
+```yaml
+    - hosts: Management_Worker
+      gather_facts: no
+      any_errors_fatal: true
+      remote_user: root
+      roles:
+        # Enable spire for SBPS Marshal Agent
+        - role: csm.sbps.enable_spire
+```
+
+License
+-------
+None.
+
+Author Information
+------------------
+
+Copyright 2024 Hewlett Packard Enterprise Development LP

--- a/ansible/roles/csm.sbps.enable_spire/tasks/main.yml
+++ b/ansible/roles/csm.sbps.enable_spire/tasks/main.yml
@@ -22,10 +22,17 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 ---
-# Enable SBPS Marshal Agent (start systemd service) on specified
-# NCN worker nodes.
-- name: enable_sbps_marshal
+
+# Enable spire for SBPS Marshal Agent
+# on specified NCN worker nodes.
+- name: enable_spire_for_sbps
+  ansible.builtin.file:
+    src: /opt/cray/cray-spire/spire-agent
+    dest: /usr/bin/sbps-marshal-spire-agent
+    state: hard
+
+- name: restart_spire_agent
   ansible.builtin.systemd:
-    name: sbps-marshal
-    state: started
+    name: spire-agent
+    state: restarted
     enabled: true

--- a/ansible/roles/csm.sbps.install_enable_marshal/README.md
+++ b/ansible/roles/csm.sbps.install_enable_marshal/README.md
@@ -1,7 +1,7 @@
-csm.sbps.enable_sbps_marshal
-============================
+csm.sbps.install_enable_marshal
+===============================
 
-Enable SBPS Marshal agent (start systemd service) on specified NCN worker nodes.
+Install and enable/ start SBPS Marshal Agent (start systemd service) on specified NCN worker nodes.
 
 Requirements
 ------------
@@ -23,8 +23,8 @@ Example Playbook
       any_errors_fatal: true
       remote_user: root
       roles:
-        # Configure SBPS
-        - role: csm.sbps.enable_sbps_marshal
+        # Install and enable/ start SBPS Marshal Agent
+        - role: csm.sbps.install_enable_marshal
 ```
 
 License

--- a/ansible/roles/csm.sbps.install_enable_marshal/tasks/main.yml
+++ b/ansible/roles/csm.sbps.install_enable_marshal/tasks/main.yml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -21,15 +21,17 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-# Tasks for the csm.gpg_keys role
-- name: Fetch Public GPG Keys from the K8S secret
-# no_log: true
-  local_action:
-    module: csm_read_secret
-    name: "{{ csm_gpg_key_k8s_secret }}"
-    namespace: "{{ csm_gpg_key_k8s_namespace }}"
-  register: hpe_gpg_pubkeys
+---
+# Install and enable/ start SBPS Marshal Agent (systemd service) on specified
+# NCN worker nodes.
+- name: install_sbps_marshal
+  zypper:
+    name: sbps-marshal
+    state: latest
+    update_cache: yes
 
-- include_tasks: install_key.yml
-  no_log: true
-  loop: "{{ hpe_gpg_pubkeys.response | dict2items }}"
+- name: enable_sbps_marshal
+  ansible.builtin.systemd:
+    name: sbps-marshal
+    state: started
+    enabled: true


### PR DESCRIPTION
    - CASMPET-7180: New CFS play for enabling spire for SBPS Marshal Agent
    - CASMPET-7195: New CFS play for install (+ previous enable) SBPS Marshal Agent
    - typo fix in DNS SRV A records creation
    - updated CHANGELOG.md

## Summary and Scope
Part of the iSCSI SBPS feature:
- Added new CFS play for enabling spire for SBPS Marshal Agent
- Added new CFS play for installing SBPS Marshal Agent (+ previous SBPS Marshal Agent enable/ start)
- Fixed typo in DVS SRV and A records creation

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing
Worker node personalization (for iSCSI SBPS) with CFS Ansible plays.

### Tested on:
Bare metal system: surtur

### Test description:
- verified that spire is enabled as appropriate.
- verified that the SBPS Marshal agent gets installed from CSM noos distribution and enables as appropriate.
- verified DNS SRV A records are created as appropriate without any fail.
- ran CFS plays for verifying the overall personalization of worker nodes w.r.t iSCSI SBPS and see that iSCSI LUNs with mapped to images are discovered/ mapped.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

None

## Pull Request Checklist

- [NA] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [ NA] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [NA ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable