### PR TITLE
MTL-1980 - Configure a bonded HSN connection on an NCN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.24.3] - 2024-09-12
+## [1.25.0] - 2024-09-12
 
 ### Added 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.24.3] - 2024-09-12
+
+### Added 
+
+- MTL-1980: Configure a bonded HSN connection on an NCN
+
 ## [1.24.2] - 2024-08-23
 
 ### Added 

--- a/ansible/ncn_hsn_bonding.yml
+++ b/ansible/ncn_hsn_bonding.yml
@@ -1,0 +1,28 @@
+#
+# MIT License
+#
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+- name: Configure HSN bonding
+  hosts: Management_Worker:!cfs_image
+
+  roles:
+    - role: csm.ncn.hsn_bonding

--- a/ansible/roles/csm.ncn.hsn_bonding/README.md
+++ b/ansible/roles/csm.ncn.hsn_bonding/README.md
@@ -1,0 +1,57 @@
+# csm.ncn.hsn_bonding
+
+Configure a bonded HSN interface on an NCN.
+
+## Requirements
+
+* The Slingshot Fabric Manager Software is installed and the fabric has been configured.
+  * A link aggregation group (LAG) has been created using the ports this node is connected to.
+* The Slingshot Host Software is installed.
+* The User Services Software is installed.
+
+## Limitations
+
+* Only one bonded interface is permitted per NCN.
+
+## Role Variables
+
+Available variables are listed below, along with default values (located in `defaults/main.yml`). These variables must be set on a per-host basis using a `host_vars` file.
+
+| Variable         | Default Value                                                                          | Description                                                                      |
+|------------------|----------------------------------------------------------------------------------------|----------------------------------------------------------------------------------|
+| hsn_bond_enable  | false                                                                                  | Set to enable HSN NIC bonding on the node.                                       |
+| hsn_bond_ip      | None. Value must be provided by Slingshot fabric administrator.                        | IP address to use for bond interface.                                            |
+| hsn_bond_netmask | None. Value must be provided by Slingshot fabric administrator.                        | Netmask to use for bond interface.                                               |
+| hsn_bond_mac     | None. Value must be provided by Slingshot fabric administrator.                        | MAC address to use for bond interface.                                           |
+| hsn_bond_name    | "bond1"                                                                                | Name to assign the bond interface.                                               |
+| hsn_bond_options | "mode=802.3ad xmit_hash_policy=layer2+3 miimon=100 ad_select=bandwidth lacp_rate=fast" | Options to be used for the bond interface.                                       |
+| rt_tablenum      | 211                                                                                    | Number to assign the routing table used for the bond interface                   |
+| rt_name          | "rt_{{hsn_bond_name}}"                                                                 | Name to assign the routing table used for the bond interface.                    |
+| hsn_bond_devices | ["macvlan0","macvlan1"]                                                                | The names of the macvlan interfaces that will be assigned to the bond interface. |
+| hsn_devices      | ["hsn0", "hsn1"]                                                                       | The names of the physical HSN interfaces that will be used for the bond.         |
+| hsn_bond_sysctls | See defaults/main.yml                                                                  | The sysctl settings that will be applied to the bond interface.                  |
+
+The `hsn_bond_ip`, `hsn_bond_netmask`, and `hsn_bond_mac` variables cannot be defaulted and must be set to values provided by the Slingshot fabric administrator.
+
+There is a one to one mapping between `hsn_bond_devices` and `hsn_devices`. For example if the default values are used then the interface `mavlan0` will be assigned the `hsn0` interface 
+and `macvlan1` will be assigned the `hsn1` interface.
+
+## Dependencies
+
+This playbook must be run after the `uss-ncn-integration` layer has run to ensure that the HSN interfaces have been configured.
+
+## Example Playbook
+
+    - hosts: Management_Worker:!cfs_image
+      roles:
+         - role: csm.ncn.hsn_bonding
+
+License
+-------
+
+MIT
+
+Author Information
+------------------
+
+Copyright 2024 Hewlett Packard Enterprise Development LP

--- a/ansible/roles/csm.ncn.hsn_bonding/README.md
+++ b/ansible/roles/csm.ncn.hsn_bonding/README.md
@@ -12,6 +12,7 @@ Configure a bonded HSN interface on an NCN.
 ## Limitations
 
 * Only one bonded interface is permitted per NCN.
+* Only systems with Cassini NICs are supported.
 
 ## Role Variables
 

--- a/ansible/roles/csm.ncn.hsn_bonding/defaults/main.yml
+++ b/ansible/roles/csm.ncn.hsn_bonding/defaults/main.yml
@@ -1,0 +1,51 @@
+#
+# MIT License
+#
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+hsn_bond_enable: false
+hsn_bond_options: "mode=802.3ad xmit_hash_policy=layer2+3 miimon=100 ad_select=bandwidth lacp_rate=fast"
+hsn_bond_name: "bond1"
+rt_tablenum: 211
+rt_name: "rt_{{hsn_bond_name}}"
+hsn_bond_devices:
+  - "macvlan0"
+  - "macvlan1"
+hsn_devices:
+  - "hsn0"
+  - "hsn1"
+hsn_bond_sysctls:
+  - name: "net.ipv4.conf.{{ hsn_bond_name }}.accept_local"
+    value: 1
+  - name: "net.ipv4.conf.{{ hsn_bond_name }}.arp_filter"
+    value: 1
+  - name: "net.ipv4.conf.{{ hsn_bond_name }}.arp_announce"
+    value: 2
+  - name: "net.ipv4.conf.{{ hsn_bond_name }}.arp_ignore"
+    value: 1
+  - name: "net.ipv4.conf.{{ hsn_bond_name }}.arp_notify"
+    value: 0
+  - name: "net.ipv4.conf.{{ hsn_bond_name }}.arp_accept"
+    value: 1
+  - name: "net.ipv4.conf.{{ hsn_bond_name }}.drop_gratuitous_arp"
+    value: 1
+  - name: "net.ipv4.conf.{{ hsn_bond_name }}.rp_filter"
+    value: 0

--- a/ansible/roles/csm.ncn.hsn_bonding/handlers/main.yml
+++ b/ansible/roles/csm.ncn.hsn_bonding/handlers/main.yml
@@ -1,0 +1,32 @@
+#
+# MIT License
+#
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# The retries are necessary because for some reason wicked fails to bring all the interfaces up first try
+
+- name: Reload interfaces
+  ansible.builtin.command:
+    cmd: 'wicked ifreload {{ hsn_bond_devices[0] + " " + hsn_bond_devices[1] + " " + hsn_bond_name }}'
+  register: result
+  retries: 3
+  delay: 2
+  until: result is not failed

--- a/ansible/roles/csm.ncn.hsn_bonding/tasks/main.yml
+++ b/ansible/roles/csm.ncn.hsn_bonding/tasks/main.yml
@@ -1,0 +1,118 @@
+#
+# MIT License
+#
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+- name: Configure HSN bonding
+  block:
+
+  - name: Check required parameters are set
+    ansible.builtin.fail:
+      msg: "Required parameter {{ item }} is not set"
+    when: 
+      - item is not defined
+    loop:
+      - "hsn_bond_ip"
+      - "hsn_bond_netmask"
+      - "hsn_bond_mac"
+
+  - name: Check required HSN interfaces exist
+    ansible.builtin.fail:
+      msg: "Required Slingshot interface {{ item }} does not exist"
+    when: 
+      - item is not in ansible_interfaces
+    loop: "{{ hsn_devices }}"
+
+  - name: Get bonded interface network
+    ansible.builtin.set_fact:
+      hsn_bond_cidr: "{{ (hsn_bond_ip + '/' + hsn_bond_netmask) | ipaddr('network/prefix') }}"
+
+  - name:  Gather HSN NIC info
+    ansible.builtin.set_fact:
+      hsn_nics: "{{ hsn_nics +  [{
+         'ifname': item,
+         'ipaddr': hostvars[inventory_hostname]['ansible_' + item].ipv4.address,
+         'netmask': hostvars[inventory_hostname]['ansible_' + item].ipv4.netmask,
+         'macaddr': hostvars[inventory_hostname]['ansible_' + item].macaddress
+      }]}}"
+    loop: "{{ hsn_devices }}"
+    vars:
+      hsn_nics: []
+
+  - name: Create routing table
+    ansible.builtin.lineinfile:
+      path: /etc/iproute2/rt_table
+      line: "{{ rt_tablenum|string + ' ' + rt_name }}"
+      state: present
+      create: true
+
+  - name: Create macvlan interface definitions
+    ansible.builtin.template:
+      src: templates/macvlan.j2
+      dest: /etc/sysconfig/network/ifcfg-{{ hsn_device.1 }}
+    loop: "{{ hsn_devices | zip(hsn_bond_devices) | list }}"
+    loop_control:
+      loop_var: hsn_device
+    notify:
+      - Reload interfaces
+
+  - name: Create bond interface
+    ansible.builtin.template:
+      src: templates/bond.j2
+      dest: /etc/sysconfig/network/ifcfg-{{ hsn_bond_name }}
+    notify:
+      - Reload interfaces
+
+  - name:  Set bond sysctl values
+    ansible.posix.sysctl:
+      name: "{{ item.name }}"
+      value: "{{ item.value }}"
+      state: present
+      sysctl_file: /etc/sysctl.d/992-{{ hsn_bond_name}}.conf
+      reload: false
+    loop: "{{ hsn_bond_sysctls }}"
+
+  - name: Set arp_filter sysctl for HSN NICs
+    ansible.posix.sysctl:
+      state: present
+      sysctl_file: /etc/sysctl.d/992-{{ hsn_bond_name}}.conf
+      reload: false
+      name: "net.ipv4.conf.{{ item }}.arp_filter"
+      value: "0"
+    loop: "{{ hsn_devices }}"
+
+  - name: Set arp_ignore sysctl for HSN NICs
+    ansible.posix.sysctl:
+      state: present
+      sysctl_file: /etc/sysctl.d/992-{{ hsn_bond_name}}.conf
+      reload: false
+      name: "net.ipv4.conf.{{ item }}.arp_ignore"
+      value: "0"
+    loop: "{{ hsn_devices }}"
+
+  - name: Generate {{ hsn_bond_name}} post-up script
+    ansible.builtin.template:
+      src: templates/script.j2
+      dest: /etc/wicked/scripts/slingshot-bond-{{ hsn_bond_name }}
+      mode: '744'
+
+  when:
+    hsn_bond_enable == true

--- a/ansible/roles/csm.ncn.hsn_bonding/templates/bond.j2
+++ b/ansible/roles/csm.ncn.hsn_bonding/templates/bond.j2
@@ -1,0 +1,9 @@
+BONDING_MASTER=yes
+BONDING_MODULE_OPTS="{{ hsn_bond_options }}"
+BONDING_SLAVE_0="{{ hsn_bond_devices[0] }}"
+BONDING_SLAVE_1="{{ hsn_bond_devices[1] }}"
+BOOTPROTO=static
+STARTMODE=auto
+IPADDR={{ hsn_bond_ip }}
+NETMASK={{ hsn_bond_netmask }}
+POST_UP_SCRIPT="wicked:slingshot-bond-{{ hsn_bond_name }}"

--- a/ansible/roles/csm.ncn.hsn_bonding/templates/macvlan.j2
+++ b/ansible/roles/csm.ncn.hsn_bonding/templates/macvlan.j2
@@ -1,0 +1,4 @@
+STARTMODE='hotplug'
+BOOTPROTO='none'
+MACVLAN_DEVICE='{{ hsn_device.0 }}'
+LLADDR='{{ hsn_bond_mac }}'

--- a/ansible/roles/csm.ncn.hsn_bonding/templates/script.j2
+++ b/ansible/roles/csm.ncn.hsn_bonding/templates/script.j2
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+action="$1"
+interface="$2"
+
+case $action in
+post-up)
+ ip route add to unicast {{ hsn_bond_cidr }} dev {{ hsn_bond_name }} src {{ hsn_bond_ip }} table {{ rt_name }} proto kernel scope host
+ ip rule add type unicast from {{ hsn_bond_ip }}/32 priority 2 table {{ rt_name }}
+ ip rule add type unicast from {{ hsn_bond_ip }}/32 to {{ hsn_bond_ip }}/32 priority 0 table local
+{% for nic in hsn_nics %}
+ ip -4 rule add type unicast from {{ hsn_bond_ip }}/32 iif {{nic.ifname}} priority 1 table local
+ ip -4 rule add type unicast from {{nic.ipaddr}}/32 iif {{ hsn_bond_name }} priority 1 table local
+ arptables-nft -A OUTPUT -o ! {{nic.ifname}} -s {{nic.ipaddr}} --jump=mangle --mangle-mac-s={{nic.macaddr}}
+ ip neigh add {{hsn_bond_ip}} lladdr {{hsn_bond_mac}} dev {{nic.ifname}} nud permanent
+ ip neigh add {{nic.ipaddr}} lladdr {{nic.macaddr}} dev {{hsn_bond_name}} nud permanent
+{% endfor %}
+ arptables-nft -A OUTPUT -o ! {{hsn_bond_name}} -s {{hsn_bond_ip}} --jump=DROP
+ ip neigh add {{ hsn_nics[0].ipaddr }} lladdr {{ hsn_nics[0].macaddr}} dev {{ hsn_nics[1].ifname }} nud permanent
+ ip neigh add {{ hsn_nics[1].ipaddr }} lladdr {{ hsn_nics[1].macaddr}} dev {{ hsn_nics[0].ifname }} nud permanent
+;;
+esac


### PR DESCRIPTION
## Summary and Scope

Ansible role to configure a bonded HSN interface on NCNs.

This role is not enabled by default as it requires values that have to be supplied by the Slingshot administrator.

## Issues and Related PRs

* Resolves [MTL-1980](https://jira-pro.it.hpe.com:8443/browse/MTL-1980)
* Documentation changes to follow in [MTL-1981](https://jira-pro.it.hpe.com:8443/browse/MTL-1981)

## Testing

### Tested on:

  * `surtur`

### Test description:

Rebuilt ncn-w005 with Playbook enabled with the following settings
```
hsn_bond_mac: "b2:00:00:00:00:01"
hsn_bond_ip: "10.253.254.1"
hsn_bond_netmask: '255.255.0.0'
hsn_bond_enable: true
```
Verified bond was configured as expected.
```
Running ncn_hsn_bonding.yml from repo https://api-gw-service-nmn.local/vcs/cray/csm-config-management.git
[WARNING]: Could not match supplied host pattern, ignoring: cfs_image

PLAY [Configure HSN bonding] ***************************************************

TASK [csm.ncn.hsn_bonding : Create routing table] ******************************
changed: [x3000c0s31b0n0]

TASK [csm.ncn.hsn_bonding : Create macvlan interface definitions] **************
changed: [x3000c0s31b0n0] => (item=['hsn0', 'macvlan0'])
changed: [x3000c0s31b0n0] => (item=['hsn1', 'macvlan1'])

TASK [csm.ncn.hsn_bonding : Create bond interface] *****************************
changed: [x3000c0s31b0n0]

TASK [csm.ncn.hsn_bonding : Set bond sysctl values] ****************************
changed: [x3000c0s31b0n0] => (item={'name': 'net.ipv4.conf.bond1.accept_local', 'value': 1})
changed: [x3000c0s31b0n0] => (item={'name': 'net.ipv4.conf.bond1.arp_filter', 'value': 1})
changed: [x3000c0s31b0n0] => (item={'name': 'net.ipv4.conf.bond1.arp_announce', 'value': 2})
changed: [x3000c0s31b0n0] => (item={'name': 'net.ipv4.conf.bond1.arp_ignore', 'value': 1})
changed: [x3000c0s31b0n0] => (item={'name': 'net.ipv4.conf.bond1.arp_notify', 'value': 0})
changed: [x3000c0s31b0n0] => (item={'name': 'net.ipv4.conf.bond1.arp_accept', 'value': 1})
changed: [x3000c0s31b0n0] => (item={'name': 'net.ipv4.conf.bond1.drop_gratuitous_arp', 'value': 1})
changed: [x3000c0s31b0n0] => (item={'name': 'net.ipv4.conf.bond1.rp_filter', 'value': 0})

TASK [csm.ncn.hsn_bonding : Set arp_filter sysctl for HSN NICs] ****************
changed: [x3000c0s31b0n0] => (item=hsn0)
changed: [x3000c0s31b0n0] => (item=hsn1)

TASK [csm.ncn.hsn_bonding : Set arp_ignore sysctl for HSN NICs] ****************
changed: [x3000c0s31b0n0] => (item=hsn0)
changed: [x3000c0s31b0n0] => (item=hsn1)

TASK [csm.ncn.hsn_bonding : Generate bond1 post-up script] *********************
changed: [x3000c0s31b0n0]
FAILED - RETRYING: Reload interfaces (3 retries left).

RUNNING HANDLER [csm.ncn.hsn_bonding : Reload interfaces] **********************
changed: [x3000c0s31b0n0]

PLAY RECAP *********************************************************************
x3000c0s31b0n0             : ok=11   changed=8    unreachable=0    failed=0    skipped=2    rescued=0    ignored=0
```
Rebooted ncn-w005, verified bond came up before CFS ran and that the Ansible playbook didn't perform any unnecessary configuration actions.
```
Running ncn_hsn_bonding.yml from repo https://api-gw-service-nmn.local/vcs/cray/csm-config-management.git
[WARNING]: Could not match supplied host pattern, ignoring: cfs_image

PLAY [Configure HSN bonding] ***************************************************

PLAY RECAP *********************************************************************
x3000c0s31b0n0             : ok=10   changed=0    unreachable=0    failed=0    skipped=2    rescued=0    ignored=0
```

## Risks and Mitigations

- Role is not enabled out of the box, it must be explicitly enabled.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

