### PR TITLE
iSCSI SBPS: Fallback to default IMS user policy for CPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.24.3] - 2024-09-13
+
+### Fixed
+
+- CASMPET-7225: Fallback to default s3fs mount of boot-images bucket with IMS user policy
+  - We must have writable access to "/var/lib/cps-local/boot-images" mount dir of "boot-images"
+    bucket in order for CPS to function and also for user to have write access for removing 
+    cos-config-data under this mount path, when he want to disable CPS.
+
+    We need to keep this fallback option till CPS is removed in USS-1.3.
+
+
 ## [1.24.2] - 2024-08-23
 
 ### Added 
@@ -498,7 +510,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ansible playbook for applying csm packages to Compute and Application nodes
 
-[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.24.2...HEAD
+[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.24.3...HEAD
+
+[1.24.3]: https://github.com/Cray-HPE/csm-config/compare/1.24.2...1.24.3
 
 [1.24.2]: https://github.com/Cray-HPE/csm-config/compare/1.24.1...1.24.2
 

--- a/ansible/config_sbps_iscsi_targets.yml
+++ b/ansible/config_sbps_iscsi_targets.yml
@@ -51,5 +51,3 @@
     - role: csm.sbps.lio_config
     # Configure SBPS DNS "SRV" and "A" records
     - role: csm.sbps.dns_srv_records
-    # Mount s3 bucket 'boot-images' using s3fs read-only policy for SBPS agent
-    - role: csm.sbps.mount_s3_images


### PR DESCRIPTION
## Summary and Scope
[CASMPET-7225](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7225): Fallback to default IMS user policy for CPS

We must have writable access to "/var/lib/cps-local/boot-images" mount directory of "boot-images" bucket order for CPS to function. CPS creates cos-config-data under "/var/lib/cps-local/boot-images"(information for the contents projected by DVS.  User also need write access while removing cos-config-data under "/var/lib/cps-local/boot-images", when he wants to disable CPS.

Since for CSM-1.6 and USS-1.2 we are supporting CPS, we need to make it writable.  When CPS will be removed in USS-1.3, we can fallback again to dedicated s3fs read-only policy.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

bare metal cluster surtur

### Tested on:

surtur

### Test description:
- Verified the CFS Ansible plays deployment with disablement of role w.r.t s3fs mount of "boot-images" bucket with s3 read only policy and see that existing mount of "boot-images" with default IMS user policy is not impacted.

## Risks and Mitigations

None

## Pull Request Checklist

- [ NA] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [ NA] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [NA] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

