### PR TITLE
CASMTRIAGE-7301: Ansible play to create iscsi-sbps-targets should not…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.27.0] - 2024-10-01
+## [1.26.1] - 2024-10-01
 
 ### Fixed
 
@@ -523,9 +523,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ansible playbook for applying csm packages to Compute and Application nodes
 
-[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.27.0...HEAD
+[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.26.1...HEAD
 
-[1.27.0]: https://github.com/Cray-HPE/csm-config/compare/1.26.0...1.27.0
+[1.26.1]: https://github.com/Cray-HPE/csm-config/compare/1.26.0...1.26.1
 
 [1.26.0]: https://github.com/Cray-HPE/csm-config/compare/1.25.0...1.26.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.27.0] - 2024-10-01
+
+### Fixed
+
+- CASMTRIAGE-7301: Ansible play to create iscsi-sbps-targets should not delegate to localhost
+  - fixed the tasks, update file (with host, HSN and NMN info) and creation of DNS SRV and A records
+    to delegate to one of the worker node instead of localhost.
+
 ## [1.26.0] - 2024-09-12
 
 ### Fixed
@@ -515,7 +523,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ansible playbook for applying csm packages to Compute and Application nodes
 
-[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.26.0...HEAD
+[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.27.0...HEAD
+
+[1.27.0]: https://github.com/Cray-HPE/csm-config/compare/1.26.0...1.27.0
 
 [1.26.0]: https://github.com/Cray-HPE/csm-config/compare/1.25.0...1.26.0
 

--- a/ansible/roles/csm.sbps.dns_srv_records/tasks/main.yml
+++ b/ansible/roles/csm.sbps.dns_srv_records/tasks/main.yml
@@ -38,12 +38,12 @@
     line: "{{ sbps_get_host_hsn_nmn.stdout | trim }}"
     state: present
     create: yes
-  delegate_to: localhost
+  delegate_to: "{{ play_hosts | first }}"
 
 # Now create DNS "SRV" and "A" records of HSN and NMN for each worker node
 - name: Create DNS "SRV" and "A" records of HSN and NMN for each worker node
   script: sbps_dns_srv_records.sh <  /tmp/hsn_nmn_info.txt
   register: sbps_dns_srv_records
   changed_when: sbps_dns_srv_records.rc == 0
-  delegate_to: localhost
+  delegate_to: "{{ play_hosts | first }}"
   run_once: true


### PR DESCRIPTION
    CASMTRIAGE-7301: Ansible play to create iscsi-sbps-targets should not delegate to localhost
      - fixed the tasks, update file (with host, HSN and NMN info) and creation of DNS SRV and A records
        to delegate to one of the worker nodes instead of localhost.

## Summary and Scope
One of the tasks of role _csm.sbps.dns_srv_records_ was failing when running in CFS environment when compared to running with standard _ansible-playbook_ command. This was due to the reason of _"delegate_to: localhost"_ where the tasks were delegated to run inside the CFS k8s job (in non CFS case _"delegate_to: localhost"_ would be the master node where plays are getting executed) and failing with _kubectl_ command not found error. Two specific tasks under this role are supposed to be run either on master node or on one of the worker nodes instead of running locally inside the CFS k8s job.

Fixed these two specific tasks to run on the 1st worker from the host inventory group (Management_Worker) and that is the best fix is what I see as we can't run these tasks on master node (original intention) in CFS environment with current _delegate_to: "{{ play_hosts | first }}"_fix when inventory is "Management_Worker". Here it will now update the file "/tmp/hsn_nmn_info.txt" on the first worker as well as invoke creation of the DNS SRV and S records on the same worker referring to "/tmp/hsn_nmn_info.txt" that should solve the purpose.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

Tested on bare metal systems: starlord and surtur

### Tested on:

Tested on bare metal systems: starlord and surtur

### Test description:
Verified the fix by running the ansible plays with CFS session/ config. Observed that all the tasks have been completed
successfully in CFS environment without any fail and also the DNS SRV and A records are created (tasks where the fix is actually applied).
...
_PLAY RECAP *********************************************************************
x3000c0s11b0n0             : ok=10   changed=5    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
x3000c0s26b0n0             : ok=9    changed=4    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
x3000c0s7b0n0              : ok=9    changed=4    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
x3000c0s9b0n0              : ok=9    changed=4    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0

All playbooks completed successfully_

## Risks and Mitigations

None

## Pull Request Checklist

- [NA] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [NA] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [NA] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable