### PR TITLE
CASMPET-7254 update hosts so CFS skips image personalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- CASMPET-7254: update hosts so CFS skips image personalization
+  - Update the config_sbps_iscsi_targets.yml playbook so that it only runs during node
+    personalization and not during image customization.
+
 ## [1.26.2] - 2024-10-09
 
 ### Fixed

--- a/ansible/config_sbps_iscsi_targets.yml
+++ b/ansible/config_sbps_iscsi_targets.yml
@@ -36,7 +36,7 @@
 # admin/ user can chose to configure only subset of worker nodes defined in 
 # CFS config/ HSM group during personalization.
 #
-- hosts: Management_Worker
+- hosts: Management_Worker:!cfs_image
   gather_facts: no
   any_errors_fatal: true
   remote_user: root


### PR DESCRIPTION
## Summary and Scope

This change updated the hosts stanza for the SBPS playbook so that if the playbook is run during image personalization using CFS/IMS the playbook won't attempt to run.   This is to allow the playbook to be added to the sat bootprep files we provide with the release.

This change should not create any backward compatibility issues as the config_sbps_iscsi_targets.yml playbook has only been used on running nodes and is documented as working that way.

## Issues and Related PRs

This change should not be dependent on any other changes that are in flight.

## Testing

This change was tested on gamora during image personalization and node customization and worked as expected.

### Tested on:

  * gamora

### Test description:

The updated playbook was tested during image customization and node personalization and worked appropriately in each instance.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?  Standard Goss tests ran post upgrade
- Were continuous integration tests run? If not, why?   No, this is a new feature
- Was upgrade tested? If not, why?   Somewhat tested.   This change was applied to a system being upgraded
- Was downgrade tested? If not, why?   No, this is a new feature
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

No known risks


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [N/A] Copyrights updated
- [x] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

