### PR TITLE
CASMTRIAGE-7428: At the initiator iscsi sessions are displayed only f…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -547,7 +547,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.27.1...HEAD
 
-[1.28.0]: https://github.com/Cray-HPE/csm-config/compare/1.27.0...1.27.1
+[1.27.1]: https://github.com/Cray-HPE/csm-config/compare/1.27.0...1.27.1
 
 [1.27.0]: https://github.com/Cray-HPE/csm-config/compare/1.26.2...1.27.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.28.0] - 2024-10-28
+## [1.27.1] - 2024-10-28
 
 ### Fixed
 
@@ -545,9 +545,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ansible playbook for applying csm packages to Compute and Application nodes
 
-[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.28.0...HEAD
+[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.27.1...HEAD
 
-[1.28.0]: https://github.com/Cray-HPE/csm-config/compare/1.27.0...1.28.0
+[1.28.0]: https://github.com/Cray-HPE/csm-config/compare/1.27.0...1.27.1
 
 [1.27.0]: https://github.com/Cray-HPE/csm-config/compare/1.26.2...1.27.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.28.0] - 2024-10-28
+
+### Fixed
+
+- CASMTRIAGE-7428: iSCSI SBPS: Fixed DNS SRV A records creation part of node personalization at
+  bootprep (management rollout).
+
 ## [1.27.0] - 2024-10-11
 
 ### Changed
@@ -538,7 +545,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ansible playbook for applying csm packages to Compute and Application nodes
 
-[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.27.0...HEAD
+[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.28.0...HEAD
+
+[1.28.0]: https://github.com/Cray-HPE/csm-config/compare/1.27.0...1.28.0
 
 [1.27.0]: https://github.com/Cray-HPE/csm-config/compare/1.26.2...1.27.0
 

--- a/ansible/roles/csm.sbps.dns_srv_records/tasks/main.yml
+++ b/ansible/roles/csm.sbps.dns_srv_records/tasks/main.yml
@@ -23,13 +23,22 @@
 #
 ---
 
-#  Create DNS "SRV" and "A" records
+# Create DNS "SRV" and "A" records
 #
+# Cleanup old tmp file on worker. We keep new tmp file
+# till the next removal for debugging purposes.
+- name: Remove previous /tmp/hsn_nmn_info.txt
+  ansible.builtin.file:
+    path: /tmp/hsn_nmn_info.txt
+    state: absent
+
 # Get Host Name, HSN IP and NMN IP of each worker node
 - name: Get Host Name, HSN and NMN details of each worker node
   script: sbps_get_host_hsn_nmn.sh
   register: sbps_get_host_hsn_nmn
   changed_when: sbps_get_host_hsn_nmn.rc == 0
+  delegate_to: "{{ play_hosts | first }}"
+  run_once: true
 
 # Update Host Name, HSN IP and NMN IP of each worker node to tmp file
 - name: Update Host Name, HSN and NMN details for each worker node
@@ -39,6 +48,7 @@
     state: present
     create: yes
   delegate_to: "{{ play_hosts | first }}"
+  run_once: true
 
 # Now create DNS "SRV" and "A" records of HSN and NMN for each worker node
 - name: Create DNS "SRV" and "A" records of HSN and NMN for each worker node


### PR DESCRIPTION
…or one worker node while SBPS is configured on all 4 worker nodes

  - Fixed DNS SRV A records creation part of node personalization part of bootprep (management rollout).

## Summary and Scope
The iSCSI SBPS node personalization from the bootprep (management rollout) creates overall only one set of DNS SRV A records (HSN + NMN) for one of the worker nodes instead of one set per each worker node. The post CSM install node personalization with CFS config/ session logic w.r.t to the DNS SRV A records creation logic broke with bootprep method and it is creating only one set of records per node wherever the CFS config is getting applied (expected) with bootprep but getting overwritten with next CFS config applied on the next worker node instead of appending. The node personalization post installation is developed in such a way that it collected the required info from all the worker nodes (by default) or to a selected worker nodes and creates the records at once from one of the worker nodes unlike applying the config to each worker node at a time part of management rollout.

With this bootprep (management rollout) way of doing things, fixed DNS SRV A records play in such a way that it collects all the hsn/nmn/host info of all the worker nodes at once using HSM api call and using host cmd and create the records for all the worker nodes whenever any worker node rollout happens irrespective of which worker is getting rolled out. This avoids creation of individual worker node records and getting overwritten each time when CFS config is applied across other nodes during management worker rollout.

## Issues and Related PRs


## Testing

drax bare metal system

### Tested on:
drax bare metal system with rc.2 bits + fix

### Test description:
Here is the list of test scenarios covered (A, B, C and D below) with fix for this issue on drax (rc2 build).

[A] Unit testing:
Manual way of kick starting the worker node personalization via CFS config/ CFS session -   [Done] - Looks Good.

[B] Update/ reapply CFS config (No IUF/ No bootprep involved)
- [B.1] CFS config update [ Done] – Looks Good
- [B.2] CFS Components update [ Done] – Looks Good

[C] Apply CFS config/ layer via bootprep (IUF) – [Done] Looks Good

[D] Re-run the IUF prepare images - creates new images and sessions template – [Done] – Looks Good]
[D.1] Image creation via iuf method
[D.2] Management rollout of worker nodes with IUF method <= wipeout and scratch rebuild [ Done] – Looks Good

[E] Compute node(s) booting
[E.1] Without compute node image creation – [ Done] – Looks Good
[E.2] With compute node image creation – [ Done] – Looks Good

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [NA] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [NA] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

