### PR TITLE
CASMTRIAGE-7447: CMN iSCSI portal can be used off system without auth…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.27.2] - 2024-10-29
+
+### Fixed
+
+- CASMTRIAGE-7447: CMN iSCSI portal can be used off system without authentication
+  - Remove CMN iSCSI portal creation from the LIO provisioning as we
+    are not using it for any projection unlike with HSN and NMN.
+
 ## [1.27.1] - 2024-10-28
 
 ### Fixed
@@ -545,7 +553,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ansible playbook for applying csm packages to Compute and Application nodes
 
-[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.27.1...HEAD
+[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.27.2...HEAD
+
+[1.27.2]: https://github.com/Cray-HPE/csm-config/compare/1.27.1...1.27.2
 
 [1.27.1]: https://github.com/Cray-HPE/csm-config/compare/1.27.0...1.27.1
 

--- a/ansible/roles/csm.sbps.lio_config/files/provision_iscsi_server.sh
+++ b/ansible/roles/csm.sbps.lio_config/files/provision_iscsi_server.sh
@@ -49,7 +49,6 @@ function add_server_target()
           targetcli "/iscsi/${TARGET_SERVER_IQN}/tpg1/portals create ${HSN_IP}" &> /dev/null
         fi
 
-        targetcli "/iscsi/${TARGET_SERVER_IQN}/tpg1/portals create ${CMN_IP}" &> /dev/null
         targetcli "/iscsi/${TARGET_SERVER_IQN}/tpg1 set attribute demo_mode_write_protect=1" &> /dev/null
         targetcli "/iscsi/${TARGET_SERVER_IQN}/tpg1 set attribute prod_mode_write_protect=1" &> /dev/null
         echo "$TARGET_SERVER_IQN"
@@ -73,7 +72,6 @@ then
 fi
 
 NMN_IP="$(host -4 "${HOST}.nmn" | awk '{print $NF;}')"
-CMN_IP="$(host -4 "${HOST}.cmn" | awk '{print $NF;}')"
 
 service target stop
 service target start


### PR DESCRIPTION
…entication

  - Remove CMN iSCSI portal creation from the LIO provisioning as we are not using it for any projection unlike with HSN and NMN.

## Summary and Scope
CASMTRIAGE-7447: iSCSI SBPS: CMN iSCSI portal can be used off system without authentication:
Since we don't use CMN iSCSI portal unlike HSN and NMN for any projection we can remove CMN iSCSI portal creation 
from the LIO provisioning to avoid security issue of discovering and login into the iSCSI targets over CMN from the UAN.

## Issues and Related PRs

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

On drax bare metal

### Tested on:

On drax bare metal (rc2) + fix


### Test description:
Tested the fixe with below cases successfully:
- CFS config of node personalization applied with booteprep - **successful**
- tested compute node booting with new config - **successful**
- CMN portal should not be configured/ listed under target cli - **successful**
- We should reject login to iSCSI targets (workers) over CMN - **successful**
-  iSCSI targets should not be discovered via CMN with "iscsiadm -m discovery" - **successfull**
-

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

None.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [NA] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [NA] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

