### PR TITLE
CASMTRIAGE-7445: iSCSI is reporting "SQUASHFS errors" on gamora for u…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- CASMTRIAGE-7445: iSCSI is reporting "SQUASHFS errors" on gamora for unknown reasons
-  - Avoid re configuration of LIO targets when they are already configured for any worker node.
+- CASMTRIAGE-7445: Avoid re configuration of LIO targets when they are already configured for any worker node.
 
 ## [1.27.2] - 2024-10-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.27.3] - 2024-11-05
+
+### Fixed
+
+- CASMTRIAGE-7445: iSCSI is reporting "SQUASHFS errors" on gamora for unknown reasons
+  - Avoid re configuration of LIO targets when they are already configured for any worker node.
+
 ## [1.27.2] - 2024-10-29
 
 ### Fixed
@@ -553,7 +560,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ansible playbook for applying csm packages to Compute and Application nodes
 
-[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.27.2...HEAD
+[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.27.3...HEAD
+
+[1.27.3]: https://github.com/Cray-HPE/csm-config/compare/1.27.2...1.27.3
 
 [1.27.2]: https://github.com/Cray-HPE/csm-config/compare/1.27.1...1.27.2
 


### PR DESCRIPTION
…nknown reasons

  - Avoid re configuration of LIO targets when they are already configured for any worker node(iSCSI target).

## Summary and Scope
CASMTRIAGE-7445: iSCSI is reporting "SQUASHFS errors" on gamora for unknown reasons:
  - Due to iSCSI targets re configuration (new iSCSI sessions being established), impacts DM device paths for iSCSI SBPS
     images will not function until they are rediscovered freshly from the iSCSI initiator (compute node).
  - Fixed to avoid re configuration of LIO targets when they are already configured for any worker node (iSCSI target).

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

drax bare metal system

### Tested on:
drax bare metal system + fix

### Test description:
- Tested re-running of the CFS config for node personalization on the worker nodes with cray cfs update, component update and cfs update with bootprep (IUF) to check to see if the LIO configuration is not re configured and initiator is not seen with SQUSHFS erros.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [NA] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [NA] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

