### PR TITLE
CASMTRIAGE-7459 iscsid needs to run on compute/UAN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.27.4] - 2024-11-08
+
+### Fixed
+
+- CASMTRIAGE-7459: Enable iscsid.service in compute/UAN nodes
+
 ## [1.27.3] - 2024-11-05
 
 ### Fixed
@@ -559,7 +565,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ansible playbook for applying csm packages to Compute and Application nodes
 
-[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.27.3...HEAD
+[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.27.4...HEAD
+
+[1.27.4]: https://github.com/Cray-HPE/csm-config/compare/1.27.3...1.27.4
 
 [1.27.3]: https://github.com/Cray-HPE/csm-config/compare/1.27.2...1.27.3
 

--- a/ansible/csm_packages.yml
+++ b/ansible/csm_packages.yml
@@ -41,6 +41,9 @@
       - cfs-state-reporter
       - csm-node-heartbeat
       - csm-node-identity
+      # CASMTRIAGE-7459
+      - iscsid
+      - multipathd
     SKERN_9187:
       - /opt/cray/cray-spire/orca-spire-agent
       - /usr/bin/ckdump-spire-agent
@@ -88,6 +91,9 @@
       - cfs-state-reporter
       - csm-node-heartbeat
       - csm-node-identity
+      # CASMTRIAGE-7459
+      - iscsid
+      - multipathd
     SKERN_9187:
       - /opt/cray/cray-spire/orca-spire-agent
       - /usr/bin/ckdump-spire-agent


### PR DESCRIPTION
## Summary and Scope
The iscsid service is the control path for iSCSI. It needs to be running when we are using iSCSI projection, so that if the worker nodes (target side) are rebooted or rebuilt, the iSCSI sessions will be recovered on the compute/UAN.

We also need to enable multipathd for when we are running with USS 1.1 for the hybrid solution (need SP5 on compute nodes for NVIDIA support).

## Issues and Related PRs

* Resolves [CASMTRIAGE-7459](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7459)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `gamora`

### Test description:

This change (having the `iscsid` service running) has been tested on `fanta`, `drax`, and `gamora`.  When the `iscsid` service is running in the compute/UAN, then when a worker node is rebooted or rebuilt, the `iscsid` service is notified by the kernel of the failure, and it re-establishes the session.

If the `iscsid` service is not running, the session to that worker node enters the faulty state, and stays in that state.

## Risks and Mitigations
If images are still being booted via DVS, then the `iscsid` service isn't being used and doesn't necessarily need to be running.  However, `iscsid` sits in a loop poll()ing for events, so if iSCSI projection isn't being used `iscsid` won't be doing anything.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

