### PR TITLE
CASMCMS-9258: Only install cfs-debugger RPM on management NCNs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.29.0] - 2025-01-24
+### Changed
+- CASMCMS-9258: Only install `cfs-debugger` RPM on management NCNs.
+
 ## [1.28.0] - 2024-12-10
 ### Fixed
 - CASMTRIAGE-7469 - fixed problems with ansible plays to build IMS remote build node image.
@@ -569,7 +573,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ansible playbook for applying csm packages to Compute and Application nodes
 
-[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.27.4...HEAD
+[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.29.0...HEAD
+
+[1.29.0]: https://github.com/Cray-HPE/csm-config/compare/1.28.0...1.29.0
+
+[1.28.0]: https://github.com/Cray-HPE/csm-config/compare/1.27.4...1.28.0
 
 [1.27.4]: https://github.com/Cray-HPE/csm-config/compare/1.27.3...1.27.4
 

--- a/ansible/vars/csm_packages.yml
+++ b/ansible/vars/csm_packages.yml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023, 2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -26,7 +26,6 @@
 
 # All nodes (Management NCNs, Application nodes, and Compute nodes)
 common_csm_sles_packages:
-  - cfs-debugger
   - cfs-state-reporter
   - cfs-trust
   - craycli
@@ -39,6 +38,7 @@ common_csm_sles_packages:
 
 # All Management NCNs (master, storage, and worker)
 common_mgmt_ncn_csm_sles_packages:
+  - cfs-debugger
   - cray-kubectl-hns-plugin
   - cray-kubectl-kubelogin-plugin
   - csm-testing
@@ -79,7 +79,6 @@ compute_csm_sles_packages:
 # base SLES packages needed for IMS remote build image
 ## NOTE - this is just common_csm_sles_packages with 'hpe-yq' removed
 ims_csm_sles_packages:
-  - cfs-debugger
   - cfs-state-reporter
   - cfs-trust
   - craycli


### PR DESCRIPTION
When doing 1.5.3 testing, we discovered that an ARM image customization failed because it could not install the cfs-debugger RPM. This package mainly makes sense to install on the NCNs, as debugging CFS issues is generally a task done by system administrators. This PR changes the Ansible so that it only installs the RPM on management NCNs.