### PR TITLE
CASMCMS-9262: Update RPM lists in vars/csm_packages.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- CASMCMS-9262: Update RPM lists in `vars/csm_packages.yml`
 
 ## [1.29.0] - 2025-01-24
 ### Changed

--- a/ansible/vars/csm_packages.yml
+++ b/ansible/vars/csm_packages.yml
@@ -38,17 +38,22 @@ common_csm_sles_packages:
 
 # All Management NCNs (master, storage, and worker)
 common_mgmt_ncn_csm_sles_packages:
+  - cani
+  - canu
   - cfs-debugger
   - cray-kubectl-hns-plugin
   - cray-kubectl-kubelogin-plugin
+  - cray-site-init
   - csm-testing
   - dracut-metal-mdsquash
   - goss-servers
   - hpe-csm-goss-package
   - hpe-csm-scripts
   - ipmitool
+  - iuf-cli
   - loftsman
   - manifestgen
+  - platform-utils
 
 # All Kubernetes Management NCNs (master and worker)
 k8s_mgmt_ncn_csm_sles_packages:
@@ -79,6 +84,7 @@ compute_csm_sles_packages:
 # base SLES packages needed for IMS remote build image
 ## NOTE - this is just common_csm_sles_packages with 'hpe-yq' removed
 ims_csm_sles_packages:
+  - bos-reporter
   - cfs-state-reporter
   - cfs-trust
   - craycli


### PR DESCRIPTION
IMS remote image build nodes should have BOS reporter.

Some other packages are currently installed on the NCNs (by cloud-init and/or in their base images), but we do not update them here. This means that if we ever ship updated versions of them, they wouldn't get applied on the nodes.