### PR TITLE
CASMPET-7443&CASMPET-7444: iSCSI SBPS projection over NMN will fail i…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `dangoslen/dependabot-changelog-helper` from 3 to 4 ([#340](https://github.com/Cray-HPE/csm-config/pull/340))
 
+## [1.32.0] - 2025-04-16
+
+### Fixed
+CASMPET-7443: correctly detect curl failures in `sbps_dns_srv_records.sh`
+CASMPET-7444: handle CRLFs in script output in `sbps_dns_srv_records.sh`
+
 ## [1.31.0] - 2025-02-18
 - CASMCMS-9282: Update to `csm-ssh-keys` to v1.7.0 for CSM 1.7
 - CASMCMS-9282: Update to `cf-gitea-import` to v1.11.0 for CSM 1.7
@@ -585,7 +591,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ansible playbook for applying csm packages to Compute and Application nodes
 
-[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.31.0...HEAD
+[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.32.0...HEAD
+
+[1.32.0]: https://github.com/Cray-HPE/csm-config/compare/1.31.0...1.32.0
 
 [1.31.0]: https://github.com/Cray-HPE/csm-config/compare/1.30.0...1.31.0
 

--- a/ansible/roles/csm.sbps.dns_srv_records/files/sbps_dns_srv_records.sh
+++ b/ansible/roles/csm.sbps.dns_srv_records/files/sbps_dns_srv_records.sh
@@ -40,6 +40,8 @@ eval "$(grep -e SITE_DOMAIN -e SYSTEM_NAME /etc/environment)"
 #   line format is: <Host Name>:<HSN IP>:<NMN IP>
 # - then create DNS SRV and A records based on the above data
 while read -r line; do
+  # Strip out any '\r' characters
+  line=$(echo "$line" | tr -d '\r')
   ncn_worker_node=$(echo "$line" | awk -F ":" '{print $1}')
   iscsi_server_id="id-$(echo "$ncn_worker_node" | awk -F "-" '{print $2}' | awk '{print substr($1,2);}')"
 
@@ -64,7 +66,7 @@ hsn_a_records="${hsn_a_records%?}"
 nmn_a_records="${nmn_a_records%?}"
 
 # PATCH (update) DNS "SRV" records for HSN and NMN for all the worker nodes
-curl -s -X PATCH -H "X-API-Key: ${PDNS_API_KEY}" "http://${PDNS_API}:8081/api/v1/servers/localhost/zones/${SYSTEM_NAME}.${SITE_DOMAIN}" -d'
+curl -sf -X PATCH -H "X-API-Key: ${PDNS_API_KEY}" "http://${PDNS_API}:8081/api/v1/servers/localhost/zones/${SYSTEM_NAME}.${SITE_DOMAIN}" -d'
 {
   "rrsets": [
     {
@@ -93,7 +95,7 @@ curl -s -X PATCH -H "X-API-Key: ${PDNS_API_KEY}" "http://${PDNS_API}:8081/api/v1
 if [[ -n $hsn_a_records ]]
 then
   # PATCH (update) DNS  "A" records for HSN for all the worker nodes
-  curl -s -X PATCH -H "X-API-Key: ${PDNS_API_KEY}" "http://${PDNS_API}:8081/api/v1/servers/localhost/zones/hsn.${SYSTEM_NAME}.${SITE_DOMAIN}" -d'
+curl -sf -X PATCH -H "X-API-Key: ${PDNS_API_KEY}" "http://${PDNS_API}:8081/api/v1/servers/localhost/zones/hsn.${SYSTEM_NAME}.${SITE_DOMAIN}" -d'
   {
     "rrsets": [
       '"${hsn_a_records}"'
@@ -102,7 +104,7 @@ then
 fi
 
 # PATCH (update) DNS  "A" records for NMN for all the worker nodes
-curl -s -X PATCH -H "X-API-Key: ${PDNS_API_KEY}" "http://${PDNS_API}:8081/api/v1/servers/localhost/zones/nmn.${SYSTEM_NAME}.${SITE_DOMAIN}" -d'
+curl -sf -X PATCH -H "X-API-Key: ${PDNS_API_KEY}" "http://${PDNS_API}:8081/api/v1/servers/localhost/zones/nmn.${SYSTEM_NAME}.${SITE_DOMAIN}" -d'
 {
   "rrsets": [
     '"${nmn_a_records}"'


### PR DESCRIPTION
…f DNS "A" (address) records for NMN are not created

  - correctly detect curl failures in sbps_dns_srv_records.sh
  - sbps_dns_srv_records.sh doesn't handle CRLFs in script output

## Summary and Scope

## Issues and Related PRs
https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7976
https://jira-pro.it.hpe.com:8443/browse/CASMPET-7443
https://jira-pro.it.hpe.com:8443/browse/CASMPET-7444

## Testing

Tested on bare metal system surtur

### Tested on:

Tested on bare metal system surtur

### Test description:
On surtur system, before applying the fix, made sure that the issue is present (No DNS SRV "A" records are present) due to CRLFs characters in "/tmp/hsn_nmn_info.txt" file which was generated by "sbps_get_host_hsn_nmn.sh" file with the old release/ source and then applied the current fix to make sure that those entries are created (Please see below for the snippets).

**Before fix:**
```
ncn-w001:~ # kubectl -n services exec -it deployment/cray-dns-powerdns -- sh -c 'pdnsutil list-all-zones | xargs -n1 pdnsutil list-zone | grep iscsi'

_sbps-hsn._tcp.surtur.hpc.amslabs.hpecorp.net   3600    IN      SRV     1 0 3260 iscsi-server-id-001.hsn.surtur.hpc.amslabs.hpecorp.net.
_sbps-hsn._tcp.surtur.hpc.amslabs.hpecorp.net   3600    IN      SRV     1 0 3260 iscsi-server-id-002.hsn.surtur.hpc.amslabs.hpecorp.net.
_sbps-hsn._tcp.surtur.hpc.amslabs.hpecorp.net   3600    IN      SRV     1 0 3260 iscsi-server-id-003.hsn.surtur.hpc.amslabs.hpecorp.net.
_sbps-hsn._tcp.surtur.hpc.amslabs.hpecorp.net   3600    IN      SRV     1 0 3260 iscsi-server-id-004.hsn.surtur.hpc.amslabs.hpecorp.net.
_sbps-hsn._tcp.surtur.hpc.amslabs.hpecorp.net   3600    IN      SRV     1 0 3260 iscsi-server-id-005.hsn.surtur.hpc.amslabs.hpecorp.net.
_sbps-nmn._tcp.surtur.hpc.amslabs.hpecorp.net   3600    IN      SRV     1 0 3260 iscsi-server-id-001.nmn.surtur.hpc.amslabs.hpecorp.net.
_sbps-nmn._tcp.surtur.hpc.amslabs.hpecorp.net   3600    IN      SRV     1 0 3260 iscsi-server-id-005.nmn.surtur.hpc.amslabs.hpecorp.net.
_sbps-nmn._tcp.surtur.hpc.amslabs.hpecorp.net   3600    IN      SRV     1 0 3260 iscsi-server-id-004.nmn.surtur.hpc.amslabs.hpecorp.net.
_sbps-nmn._tcp.surtur.hpc.amslabs.hpecorp.net   3600    IN      SRV     1 0 3260 iscsi-server-id-003.nmn.surtur.hpc.amslabs.hpecorp.net.
_sbps-nmn._tcp.surtur.hpc.amslabs.hpecorp.net   3600    IN      SRV     1 0 3260 iscsi-server-id-002.nmn.surtur.hpc.amslabs.hpecorp.net.
iscsi-server-id-001.hsn.surtur.hpc.amslabs.hpecorp.net  3600    IN      A       10.253.0.2
iscsi-server-id-002.hsn.surtur.hpc.amslabs.hpecorp.net  3600    IN      A       10.253.0.4
iscsi-server-id-003.hsn.surtur.hpc.amslabs.hpecorp.net  3600    IN      A       10.253.0.6
iscsi-server-id-004.hsn.surtur.hpc.amslabs.hpecorp.net  3600    IN      A       10.253.0.14
iscsi-server-id-005.hsn.surtur.hpc.amslabs.hpecorp.net  3600    IN      A       10.253.0.24
ncn-w001:~ #
```

**After fix:**
```
ncn-w001:~ # kubectl -n services exec -it deployment/cray-dns-powerdns -- sh -c 'pdnsutil list-all-zones | xargs -n1 pdnsutil list-zone | grep iscsi'
_sbps-hsn._tcp.surtur.hpc.amslabs.hpecorp.net   3600    IN      SRV     1 0 3260 iscsi-server-id-002.hsn.surtur.hpc.amslabs.hpecorp.net.
_sbps-hsn._tcp.surtur.hpc.amslabs.hpecorp.net   3600    IN      SRV     1 0 3260 iscsi-server-id-001.hsn.surtur.hpc.amslabs.hpecorp.net.
_sbps-hsn._tcp.surtur.hpc.amslabs.hpecorp.net   3600    IN      SRV     1 0 3260 iscsi-server-id-003.hsn.surtur.hpc.amslabs.hpecorp.net.
_sbps-hsn._tcp.surtur.hpc.amslabs.hpecorp.net   3600    IN      SRV     1 0 3260 iscsi-server-id-004.hsn.surtur.hpc.amslabs.hpecorp.net.
_sbps-hsn._tcp.surtur.hpc.amslabs.hpecorp.net   3600    IN      SRV     1 0 3260 iscsi-server-id-005.hsn.surtur.hpc.amslabs.hpecorp.net.
_sbps-nmn._tcp.surtur.hpc.amslabs.hpecorp.net   3600    IN      SRV     1 0 3260 iscsi-server-id-005.nmn.surtur.hpc.amslabs.hpecorp.net.
_sbps-nmn._tcp.surtur.hpc.amslabs.hpecorp.net   3600    IN      SRV     1 0 3260 iscsi-server-id-001.nmn.surtur.hpc.amslabs.hpecorp.net.
_sbps-nmn._tcp.surtur.hpc.amslabs.hpecorp.net   3600    IN      SRV     1 0 3260 iscsi-server-id-002.nmn.surtur.hpc.amslabs.hpecorp.net.
_sbps-nmn._tcp.surtur.hpc.amslabs.hpecorp.net   3600    IN      SRV     1 0 3260 iscsi-server-id-003.nmn.surtur.hpc.amslabs.hpecorp.net.
_sbps-nmn._tcp.surtur.hpc.amslabs.hpecorp.net   3600    IN      SRV     1 0 3260 iscsi-server-id-004.nmn.surtur.hpc.amslabs.hpecorp.net.
iscsi-server-id-001.nmn.surtur.hpc.amslabs.hpecorp.net  3600    IN      A       10.252.1.9
iscsi-server-id-002.nmn.surtur.hpc.amslabs.hpecorp.net  3600    IN      A       10.252.1.8
iscsi-server-id-003.nmn.surtur.hpc.amslabs.hpecorp.net  3600    IN      A       10.252.1.7
iscsi-server-id-004.nmn.surtur.hpc.amslabs.hpecorp.net  3600    IN      A       10.252.1.13
iscsi-server-id-005.nmn.surtur.hpc.amslabs.hpecorp.net  3600    IN      A       10.252.1.14
iscsi-server-id-001.hsn.surtur.hpc.amslabs.hpecorp.net  3600    IN      A       10.253.0.2
iscsi-server-id-002.hsn.surtur.hpc.amslabs.hpecorp.net  3600    IN      A       10.253.0.4
iscsi-server-id-003.hsn.surtur.hpc.amslabs.hpecorp.net  3600    IN      A       10.253.0.6
iscsi-server-id-004.hsn.surtur.hpc.amslabs.hpecorp.net  3600    IN      A       10.253.0.14
iscsi-server-id-005.hsn.surtur.hpc.amslabs.hpecorp.net  3600    IN      A       10.253.0.24
ncn-w001:~ #
```

## Risks and Mitigations

None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [NA] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [NA] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable