### PR TITLE
CASMPET-7260: During bootprep provide a method to select specific worker nodes for node personalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.35.0] - 2025-05-28
+
+### Added
+- CASMPET-7260
+  - Added support for selective worker node personalization for iSCSI SBPS
+  - This achieved by creating HSM groups before bootprep time
+  - Added HSM group name `iscsi_worker` in `config_sbps_iscsi_targets.yml` in place of `Management_Worker`
+
 ## [1.34.0] - 2025-05-27
 
 ### Added
@@ -622,7 +630,9 @@ CASMPET-7444: handle CRLFs in script output in `sbps_dns_srv_records.sh`
 
 - Ansible playbook for applying csm packages to Compute and Application nodes
 
-[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.34.0...HEAD
+[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.35.0...HEAD
+
+[1.35.0]: https://github.com/Cray-HPE/csm-config/compare/1.34.0...1.35.0
 
 [1.34.0]: https://github.com/Cray-HPE/csm-config/compare/1.33.0...1.34.0
 

--- a/ansible/config_sbps_iscsi_targets.yml
+++ b/ansible/config_sbps_iscsi_targets.yml
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2024-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/ansible/config_sbps_iscsi_targets.yml
+++ b/ansible/config_sbps_iscsi_targets.yml
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -36,7 +36,7 @@
 # admin/ user can chose to configure only subset of worker nodes defined in 
 # CFS config/ HSM group during personalization.
 #
-- hosts: Management_Worker:!cfs_image
+- hosts: iscsi_worker:!cfs_image
   gather_facts: no
   any_errors_fatal: true
   remote_user: root


### PR DESCRIPTION
## Summary and Scope

Currently on worker node are configured for iSCSI (iSCSI target) via node personalization. As all nodes are not required to be iSCSI targets, we need to have selective worker node personalization. This is achieved by creating HSM groups. 

## Issues and Related PRs

* Resolves [issue id](issue link): CASMPET-7260
* Change will also be needed in `<insert branch name here>`: N/A 
* Future work required by [issue id](issue link): N/A 
* Documentation changes required in [issue id](issue link): CASMPET-7556
* Merge with/before/after `<insert PR URL here>`: N/A

## Testing
Testing is done on drax, tyr and starlord. 

Tested on drax (CSM 1.6.2-rc.1), Tyr (CSM 1.6.1-rc.7) and starlord (CSM 1.7.0-alpha.11)

### Tested on:
Tested on drax (CSM 1.6.2-rc.1), Tyr (CSM 1.6.1-rc.7) and starlord (CSM 1.7.0-alpha.11)

### Test description:
Created HSM group having single and dual node and verified node personalization scripts execution on the nodes which are in HSM group in CFS pod logs after CFS config update and CFS components update.
Created HSM group having single and dual node and verified node personalization scripts execution on the nodes which are in HSM group in CFS pod logs after CFS session config update and CFS session creation. 

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?: yes
- Were continuous integration tests run? If not, why?: N/A
- Was upgrade tested? If not, why?: N/A 
- Was downgrade tested? If not, why?: N/A 
- Were new tests (or test issues/Jiras) created for this change?: No

## Risks and Mitigations
None. 

## Pull Request Checklist

- [NA ] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [NA ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [NA] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable