### PR TITLE
CASMCMS-9445: Remove cray-uai-util from package list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- CASMCMS-9445: Remove `cray-uai-util` from package list (since UAI/UAS was removed in CSM 1.6)
+
 ## [1.35.0] - 2025-05-28
 
 ### Added

--- a/ansible/vars/csm_packages.yml
+++ b/ansible/vars/csm_packages.yml
@@ -74,7 +74,6 @@ storage_mgmt_ncn_csm_sles_packages:
 application_csm_sles_packages:
   - bos-reporter
   - cray-node-exporter
-  - cray-uai-util
   - smart-mon
   - smartmontools
   - cray-spire-dracut>=2.0.0
@@ -82,7 +81,6 @@ application_csm_sles_packages:
 # All Compute nodes
 compute_csm_sles_packages:
   - bos-reporter
-  - cray-uai-util
   - cray-spire-dracut>=2.0.0
   - csm-netif-dracut
   - csm-sbps-dracut


### PR DESCRIPTION
UAS/UAI were removed in CSM 1.6. This removes the `cray-uai-util` from the packages list.