### PR TITLE
Casmtriage 8171 fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,19 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.39.0] - 2025-06-16
+## [1.40.0] - 2025-06-18
+
 - CASMTRIAGE-8171
   - Changed the order of iSCSI ansible play books execution in `config_sbps_iscsi_targets.yml`
-  - Added disable the target port functionality in `provision_iscsi_server.sh` 
+  - Added target port disable functionality in `provision_iscsi_server.sh`
 
-### Added
+## [1.39.0] - 2025-06-17
 
+### Changed
+
+- MTL-2581: move uss specific packages into separate vars file to avoid installing them in csm compute images
 
 ## [1.38.0] - 2025-06-03
+
+### Removed
 
 - CASMMON-534: Remove `cray-node-exporter` from package list.
 
 ## [1.37.0] - 2025-05-28
+
+### Removed
 
 - CASMCMS-9447: Remove top-level playbooks that have been deprecated (in favor of `ncn_nodes.yml`) since CSM 1.4:
   - `ncn-master_nodes.yml`
@@ -35,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.35.0] - 2025-05-28
 
 ### Added
+
 - CASMPET-7260
   - Added support for selective worker node personalization for iSCSI SBPS
   - This achieved by creating HSM groups before bootprep time
@@ -43,12 +52,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.34.0] - 2025-05-27
 
 ### Added
+
 - CASMCMS-9439
   - Added `csm.ssh_config` roles to restore user SSH configuration from Vault
   - Added calls to this role to top-level NCN playbooks that called `csm.ssh_keys`
   - Created new top-level playbook `rotate-ssh-config-mgmt-nodes.yml`, akin to `rotate-ssh-keys-mgmt-nodes.yml`
 
 ### Changed
+
 - MTL-2569/MTL-2574/MTL-2556/MTL-2555/MTL-2573: RPMs transferred from COS to CSM
   - csm-sbps-dracut
   - csm-sbps-utils
@@ -57,7 +68,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - csm-scripts-dracut
 
 ## [1.33.0] - 2025-05-12
+
 ### Added
+
 - CASM-4872: Rack Resiliency (RR): Provide a method for placement discovery and validation of management nodes in order to meet the RR norms
 - CASM-4873: Rack Resiliency (RR): Define, create, and configure Management Plane Failure Domains and handle enablement/disablement of the RR feature
 
@@ -72,31 +85,43 @@ RR Ansible plays for:
 ## [1.32.0] - 2025-04-16
 
 ### Fixed
-CASMPET-7443: correctly detect curl failures in `sbps_dns_srv_records.sh`
-CASMPET-7444: handle CRLFs in script output in `sbps_dns_srv_records.sh`
+
+- CASMPET-7443: correctly detect curl failures in `sbps_dns_srv_records.sh`
+- CASMPET-7444: handle CRLFs in script output in `sbps_dns_srv_records.sh`
 
 ### Changed
+
 - CASMTRIAGE-8069: Add `net.ipv4.neigh.default.base_reachable_time_ms` to `roles/csm.ncn.sysctl/vars/main.yml`
 
 ### Dependencies
+
 - Bump `dangoslen/dependabot-changelog-helper` from 3 to 4 ([#340](https://github.com/Cray-HPE/csm-config/pull/340))
 
 ## [1.31.0] - 2025-02-18
+
+### Dependencies
+
 - CASMCMS-9282: Update to `csm-ssh-keys` to v1.7.0 for CSM 1.7
 - CASMCMS-9282: Update to `cf-gitea-import` to v1.11.0 for CSM 1.7
 
 ## [1.30.0] - 2025-01-30
+
 ### Changed
+
 - CASMCMS-9262: Update RPM lists in `vars/csm_packages.yml`
 
 ## [1.29.0] - 2025-01-24
+
 ### Changed
+
 - CASMCMS-9258: Only install `cfs-debugger` RPM on management NCNs.
 
 ## [1.28.0] - 2024-12-10
+
 ### Fixed
+
 - CASMTRIAGE-7469 - fixed problems with ansible plays to build IMS remote build node image.
-/han
+
 ## [1.27.4] - 2024-11-08
 
 ### Fixed
@@ -655,7 +680,11 @@ CASMPET-7444: handle CRLFs in script output in `sbps_dns_srv_records.sh`
 
 - Ansible playbook for applying csm packages to Compute and Application nodes
 
-[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.38.0...HEAD
+[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.40.0...HEAD
+
+[1.40.0]: https://github.com/Cray-HPE/csm-config/compare/1.39.0...1.40.0
+
+[1.39.0]: https://github.com/Cray-HPE/csm-config/compare/1.38.0...1.39.0
 
 [1.38.0]: https://github.com/Cray-HPE/csm-config/compare/1.37.0...1.38.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.39.0] - 2025-06-16
+- CASMTRIAGE-8171
+  - Changed the order of iSCSI ansible play books execution in `config_sbps_iscsi_targets.yml`
+  - Added disable the target port functionality in `provision_iscsi_server.sh` 
+
+### Added
+
+
 ## [1.38.0] - 2025-06-03
 
 - CASMMON-534: Remove `cray-node-exporter` from package list.
@@ -88,7 +96,7 @@ CASMPET-7444: handle CRLFs in script output in `sbps_dns_srv_records.sh`
 ## [1.28.0] - 2024-12-10
 ### Fixed
 - CASMTRIAGE-7469 - fixed problems with ansible plays to build IMS remote build node image.
-
+/han
 ## [1.27.4] - 2024-11-08
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.40.0] - 2025-06-18
 
+### Changed
+
 - CASMTRIAGE-8171
   - Changed the order of iSCSI ansible play books execution in `config_sbps_iscsi_targets.yml`
   - Added target port disable functionality in `provision_iscsi_server.sh`

--- a/ansible/config_sbps_iscsi_targets.yml
+++ b/ansible/config_sbps_iscsi_targets.yml
@@ -45,9 +45,9 @@
     - role: csm.sbps.apply_label
     # Enable spire for SBPS Marshal Agent (systemd service)
     - role: csm.sbps.enable_spire
-    # Install and enable SBPS Marshal Agent
-    - role: csm.sbps.install_enable_marshal
     # Provision iSCSI targets/ LIO services
     - role: csm.sbps.lio_config
+    # Install and enable SBPS Marshal Agent
+    - role: csm.sbps.install_enable_marshal
     # Configure SBPS DNS "SRV" and "A" records
     - role: csm.sbps.dns_srv_records

--- a/ansible/roles/csm.sbps.lio_config/files/provision_iscsi_server.sh
+++ b/ansible/roles/csm.sbps.lio_config/files/provision_iscsi_server.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2024-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -98,6 +98,5 @@ SERVER_IQN="$(add_server_target)"
 #--------------------------------------------------------------------
 
 auto_generate_node_acls "$SERVER_IQN"
-targetcli "/iscsi/${TARGET_SERVER_IQN}/tpg1" disable
 disable_target_port
 save_server_config

--- a/ansible/roles/csm.sbps.lio_config/files/provision_iscsi_server.sh
+++ b/ansible/roles/csm.sbps.lio_config/files/provision_iscsi_server.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -70,6 +70,11 @@ function auto_generate_node_acls()
         targetcli "/iscsi/${TARGET_SERVER_IQN}/tpg1 set attribute generate_node_acls=1"
 }
 
+function disable_target_port()
+{
+        targetcli "/iscsi/${TARGET_SERVER_IQN}/tpg1" disable
+}
+
 #--------------------------------------------------------------------
 # Base Target Configuration
 #--------------------------------------------------------------------
@@ -93,4 +98,6 @@ SERVER_IQN="$(add_server_target)"
 #--------------------------------------------------------------------
 
 auto_generate_node_acls "$SERVER_IQN"
+targetcli "/iscsi/${TARGET_SERVER_IQN}/tpg1" disable
+disable_target_port
 save_server_config


### PR DESCRIPTION
## Summary and Scope

 Worker node hung due to flood of NON_EXISTENT_LUN messages with rebuild of the node.
 - Changed the order of iSCSI ansible play books execution where LIO config is first and then SBPS Mrashal agent installation and configuration
 - Disable the target port after the portals are created
 - The fix is spread across 'csm-config' repo as well as 'sbps-marshal' repo
 
## Issues and Related PRs
The fix is spread across "csm-config" repo and "sbps-marsha" repo for which PR to be raised.

* Resolves [CASMTRIAGE-8171](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8171)
* Change will also be needed in `<insert branch name here>`: N/A
* Future work required by [issue id](issue link): N/A 
* Documentation changes required in [issue id](issue link): N/A 
* Merge with/before/after `<insert PR URL here>`: N/A 

## Testing
Unit test results are uploaded to Jira ticket [CASMTRIAGE-8171-Unit-test.txt]

### Tested on:
Lemon drop where CSM 1.6.1-rc.7 is installed. 

### Test description:
Unit test results attached with the Jira has all the details and snippets.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?:  Yes
- Were continuous integration tests run? If not, why?: N/A 
- Was upgrade tested? If not, why?: TBD
- Was downgrade tested? If not, why?: N/A 
- Were new tests (or test issues/Jiras) created for this change?: No

## Risks and Mitigations
None.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [NA ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable