### PR TITLE
CASMPET-7616: Modify iSCSI playbook to be aware of new HSM group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- CASMPET-7616: Modify iSCSI playbook to be aware of new HSM group
+  - The playbook runs on all worker nodes, and does the iSCSI configuration on all of them.
+  - The `csm.sbps.apply_label` role behavior has changed. Now all workers in the group will have the
+    label applied to them, and all workers not in the group will have the label removed from them.
+  - The `csm.sbps.dns_srv_records` role previously queried SLS and made DNS entries for all worker
+    nodes. Now it instead does this for all worker nodes that have the iSCSI Kubernetes label.
+  - For the purposes of these changes, if the new HSM group does not exist, it is the same as if it
+    exists and all workers belong to it.
+
 ## [1.41.0] - 2025-06-25
 
 ### Changed

--- a/ansible/config_sbps_iscsi_targets.yml
+++ b/ansible/config_sbps_iscsi_targets.yml
@@ -32,14 +32,26 @@
 #   - mount s3 bucket (boot-image) images using new dedicated s3 read only policy
 #   - apply k8s label to the personalized nodes for other consumers of iSCSI SBPS
 # 
-# By default all the worker nodes (Management_Worker) will be configured OR 
-# admin/ user can chose to configure only subset of worker nodes defined in 
-# CFS config/ HSM group during personalization.
+# All the worker nodes (Management_Worker) will be configured.
+# By default, all of the worker nodes will have the Kubernetes iscsi label applied, and will
+# be included in the DNS record updates. This is the case unless
+# the HSM group defined below (under iscsi_group_name) exists. If that HSM group exists,
+# then:
+# 1. All worker nodes belonging to that group will have the Kubernetes iscsi label applied, and will
+#    be included in the DNS record updates.
+# 2. All worker nodes NOT belonging to that group will have the Kubernetes iscsi label removed, and
+#    it will not be included in the DNS record updates. However, if it was included on a previous
+#    run of this playbook, then removal of the DNS records must be done manually by the administrator.
 #
-- hosts: iscsi_worker:!cfs_image
-  gather_facts: no
+- hosts: Management_Worker:!cfs_image
+  gather_facts: yes
+  # We need to get ansible_hostname set
+  gather_subset: min
   any_errors_fatal: true
   remote_user: root
+  vars:
+    iscsi_group_name: "iscsi_worker"
+    iscsi_label_value: "sbps"
   roles:
     # Apply k8s label on all the intended worker nodes
     - role: csm.sbps.apply_label

--- a/ansible/roles/csm.sbps.apply_label/README.md
+++ b/ansible/roles/csm.sbps.apply_label/README.md
@@ -14,7 +14,7 @@ Role Variables
 | *Variable*          | *Description*       |
 | ------------------- | ------------------- |
 | `iscsi_group_name`  | Name of the HSM group that can be used to limit the iSCSI worker nodes (default: `iscsi_worker`)                           |
-| `iscsi_label_value` | Value of the Kubernetes `iscsi` label trhat indicates a worker is intended to be used as an iSCSI target (default: `sbps`) |
+| `iscsi_label_value` | Value of the Kubernetes `iscsi` label that indicates a worker is intended to be used as an iSCSI target (default: `sbps`) |
 
 Dependencies
 ------------

--- a/ansible/roles/csm.sbps.apply_label/README.md
+++ b/ansible/roles/csm.sbps.apply_label/README.md
@@ -6,10 +6,15 @@ Apply k8s label on intended worker nodes
 Requirements
 ------------
 
-None.
+ansible_hostname must be set (`gather_subset: min`)
 
 Role Variables
 --------------
+
+| *Variable*          | *Description*       |
+| ------------------- | ------------------- |
+| `iscsi_group_name`  | Name of the HSM group that can be used to limit the iSCSI worker nodes (default: `iscsi_worker`)                           |
+| `iscsi_label_value` | Value of the Kubernetes `iscsi` label trhat indicates a worker is intended to be used as an iSCSI target (default: `sbps`) |
 
 Dependencies
 ------------
@@ -19,9 +24,14 @@ Example Playbook
 
 ```yaml
     - hosts: Management_Worker
-      gather_facts: no
+      gather_facts: yes
+      # We need to get ansible_hostname set
+      gather_subset: min
       any_errors_fatal: true
       remote_user: root
+      vars:
+        iscsi_group_name: "iscsi_worker"
+        iscsi_label_value: "sbps"
       roles:
         # Apply k8s label on intended worker nodes
         - role: csm.sbps.apply_k8s_label

--- a/ansible/roles/csm.sbps.apply_label/defaults/main.yml
+++ b/ansible/roles/csm.sbps.apply_label/defaults/main.yml
@@ -1,8 +1,7 @@
-#!/bin/bash
 #
 # MIT License
 #
-# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -22,12 +21,5 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-
-LABEL="iscsi=sbps"
-HOST_NAME="$(awk '{print $1}' /etc/hostname)"
-
-# If the label is already applied to this node, then exit
-kubectl get nodes -l "$LABEL" --no-headers | grep -Eq "^${HOST_NAME}[[:space:]]" && exit 0
-
-# Otherwise, apply the label to the node
-kubectl label nodes "$HOST_NAME" "$LABEL"
+iscsi_group_name: "iscsi_worker"
+iscsi_label_value: "sbps"

--- a/ansible/roles/csm.sbps.apply_label/tasks/main.yml
+++ b/ansible/roles/csm.sbps.apply_label/tasks/main.yml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2024-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -23,8 +23,41 @@
 #
 ---
 
-#  Apply k8s label on all the intended worker nodes
-- name: Apply k8s label on worker nodes
-  script: apply_k8s_label.sh
-  register: apply_k8s_label
-  changed_when: apply_k8s_label.rc == 0
+# By default all the worker nodes (Management_Worker) will be configured, unless
+# the HSM group defined below (under iscsi_group_name) exists. If that HSM group exists,
+# then all workers belonging to that group will be configured.
+
+#  Add or remove the k8s label on worker nodes to match the HSM group
+- name: Get Kubernetes node info
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Node
+    name: "{{ansible_hostname}}"
+  register: node_info
+  failed_when: node_info.resources is not defined or node_info.resources | length == 0
+- name: Check iSCSI label and HSM group
+  set_fact:
+    has_iscsi_label: "{{ 'iscsi' in node_info.resources[0].metadata.labels and node_info.resources[0].metadata.labels['iscsi'] == iscsi_label_value }}"
+    # {{groups}} is a variable containing all host groups. CFS creates a host group for every HSM group.
+    # {{group_names}} is a list of host groups to which the current host belongs.
+    intended_for_iscsi: "{{ (iscsi_group_name not in groups) or (iscsi_group_name in group_names) }}"
+- name: Add label
+  kubernetes.core.k8s:
+    api_version: v1
+    kind: Node
+    name: "{{ansible_hostname}}"
+    definition:
+      metadata:
+        labels:
+          iscsi: "{{iscsi_label_value}}"
+  when: intended_for_iscsi and not has_iscsi_label
+- name: Remove label
+  kubernetes.core.k8s:
+    api_version: v1
+    kind: Node
+    name: "{{ansible_hostname}}"
+    definition:
+      metadata:
+        labels:
+          iscsi: null
+  when: not intended_for_iscsi and has_iscsi_label

--- a/ansible/roles/csm.sbps.dns_srv_records/files/sbps_get_host_hsn_nmn.sh
+++ b/ansible/roles/csm.sbps.dns_srv_records/files/sbps_get_host_hsn_nmn.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2024-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -25,9 +25,9 @@
 
 set -euo pipefail
 
-get-token ()
+function get-token ()
 {
-    export TOKEN=$(curl -s -S -d grant_type=client_credentials -d client_id=admin-client -d client_secret=`kubectl get secrets admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` "https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token" | jq -r '.access_token')
+    TOKEN=$(curl -s -S -d grant_type=client_credentials -d client_id=admin-client -d client_secret=`kubectl get secrets -n default admin-client-auth -o jsonpath='{.data.client-secret}' | base64 -d` "https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token" | jq -r '.access_token')
 }
 
 function authcurl()
@@ -36,16 +36,17 @@ function authcurl()
     curl -H "Authorization: Bearer ${TOKEN}" "$@"
 }
 
-function xname2hostname()
+function hostname2xname()
 {
-    local XNAME="$1"
-    authcurl -sk -X GET https://api-gw-service-nmn.local/apis/sls/v1/hardware/${XNAME} | jq .ExtraProperties.Aliases[] -r | head -n 1
+    local HNAME="$1"
+    authcurl -sk -X GET https://api-gw-service-nmn.local/apis/bss/boot/v1/bootparameters | jq -r '.[] | select(."cloud-init"."meta-data"."local-hostname" == "'${HNAME}'") | .hosts[0]' | head -n 1
 }
 
-for h in $( authcurl -s "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components?role=Management&subrole=Worker" | jq .Components[].ID -r ); do
-    NMN_IP="$( host $h | grep "has address" | tail -n 1 | awk '{ print $NF }' )"
-    HSN_IP="$( host ${h}h0 | grep "has address" | tail -n 1 | awk '{ print $NF }' || true )"
-    RHOST="$( xname2hostname $h )"
+# Use the presence of the iscsi Kubernetes label as the basis of which hosts to include
+for h in $(kubectl get nodes -l iscsi=sbps -o custom-columns=:.metadata.name --no-headers); do
+    xname=$(hostname2xname "${h}")
+    NMN_IP="$( host $xname | grep "has address" | tail -n 1 | awk '{ print $NF }' )"
+    HSN_IP="$( host ${xname}h0 | grep "has address" | tail -n 1 | awk '{ print $NF }' || true )"
 
-    echo $RHOST:$HSN_IP:$NMN_IP
-done | sort
+    echo $h:$HSN_IP:$NMN_IP
+done | sort -u


### PR DESCRIPTION
## Summary and Scope

This modifies the main iSCSI playbook so that it runs on all worker nodes. However, its behavior on them is now different based on the new HSM group.

For all changes described here, if the HSM group does not exist, then it works exactly the same as if the HSM group exists and all workers belong to it.

### `apply_label` role

The `apply_label` role now both adds or removes the iSCSI Kubernetes label. For all nodes in the group, it is added, and for all nodes not in the group, it is removed. 

In the process of making this change, I also got rid of the previous shell script, and implemented this using the Ansible kubernetes module.

Right now this is being done on each worker node, but a good improvement to this would be to have this just run once on a single node, since nothing it is doing involves the actual node itself. In the interest of time, I did not make this improvement.

### `dns_src_records` role

The first script in this role is used to collect IP information about all of the workers. This PR changes it so that it only collects this information about workers with the iSCSI Kubernetes label. Notably, this means that it is starting with a list of hostnames (`ncn-w001`, etc) rather than xnames. The current script was the reverse, and thus had a function defined for converting the xnames into hostnames. My change involved reversing that, so the function does the conversion the other way. The way I've most often seen this done is using BSS, which is what I did here, but I am open to suggestions for changing it. Presumably I could also just dump the same SLS data used before, but instead dig through it to find the hostnames, and then see which xnames they were associated with.

This role could also be largely re-written to use more Ansible and less shell scripting, but again, time constraints forced me to avoid looking into that at the moment.

## Issues and Related PRs

* [CASMPET-7616](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7616)

## Testing

I tested this on wasp. I verified that it works as expected when the HSM group does not exist, and when it exists and has all workers, and when it exists and is missing some of the workers.

## Pull Request Checklist

- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
