### PR TITLE
CASMPET-7624/CASMPET-7625: apply_label role improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.42.1] - 2025-07-14
+
+### Changed
+
+- CASMPET-7624: Add check to beginning of `csm.sbps.apply_label`, to make sure that if the HSM iSCSI
+  group exists, that it contains at least one worker NCN. If it does not, fail the playbook for all hosts
+  with an appropriate error message.
+
 ## [1.42.0] - 2025-07-10
 
 ### Changed
@@ -701,7 +709,9 @@ RR Ansible plays for:
 
 - Ansible playbook for applying csm packages to Compute and Application nodes
 
-[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.42.0...HEAD
+[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.42.1...HEAD
+
+[1.42.1]: https://github.com/Cray-HPE/csm-config/compare/1.42.0...1.42.1
 
 [1.42.0]: https://github.com/Cray-HPE/csm-config/compare/1.41.0...1.42.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.42.1] - 2025-07-14
+## [1.42.1] - 2025-07-15
 
 ### Changed
-
 - CASMPET-7624: Add check to beginning of `csm.sbps.apply_label`, to make sure that if the HSM iSCSI
   group exists, that it contains at least one worker NCN. If it does not, fail the playbook for all hosts
   with an appropriate error message.
+- CASMPET-7625: Modified apply_label role to run only once, and inside the CFS pod, since nothing it does requires
+  the target nodes to be up and running. This will allow node labels to be updated for every worker, whether or not they
+  are up at the time the playbook is run.
 
 ## [1.42.0] - 2025-07-10
 

--- a/ansible/config_sbps_iscsi_targets.yml
+++ b/ansible/config_sbps_iscsi_targets.yml
@@ -44,9 +44,7 @@
 #    run of this playbook, then removal of the DNS records must be done manually by the administrator.
 #
 - hosts: Management_Worker:!cfs_image
-  gather_facts: yes
-  # We need to get ansible_hostname set
-  gather_subset: min
+  gather_facts: no
   any_errors_fatal: true
   remote_user: root
   vars:

--- a/ansible/roles/csm.sbps.apply_label/README.md
+++ b/ansible/roles/csm.sbps.apply_label/README.md
@@ -1,19 +1,27 @@
 csm.sbps.apply_label
 ========================
 
-Apply k8s label on intended worker nodes
+Add or remove Kubernetes label to worker nodes.
+
+If the specified HSM group (specified by the `iscsi_group_name` variable) does not exist,
+then all worker nodes should have the label.
+If the specified HSM group exists, then only worker nodes that belong to that group should
+have the label; all other worker nodes should not have the label.
+
+This role determines which workers should have the label, determines which workers currently have
+the label, and modifies things so that the current state matches the expected state.
 
 Requirements
 ------------
 
-ansible_hostname must be set (`gather_subset: min`)
+None
 
 Role Variables
 --------------
 
 | *Variable*          | *Description*       |
 | ------------------- | ------------------- |
-| `iscsi_group_name`  | Name of the HSM group that can be used to limit the iSCSI worker nodes (default: `iscsi_worker`)                           |
+| `iscsi_group_name`  | Name of the HSM group that can be used to limit the iSCSI worker nodes (default: `iscsi_worker`)                          |
 | `iscsi_label_value` | Value of the Kubernetes `iscsi` label that indicates a worker is intended to be used as an iSCSI target (default: `sbps`) |
 
 Dependencies
@@ -24,9 +32,7 @@ Example Playbook
 
 ```yaml
     - hosts: Management_Worker
-      gather_facts: yes
-      # We need to get ansible_hostname set
-      gather_subset: min
+      gather_facts: no
       any_errors_fatal: true
       remote_user: root
       vars:
@@ -44,4 +50,4 @@ None.
 Author Information
 ------------------
 
-Copyright 2024 Hewlett Packard Enterprise Development LP
+Copyright 2024-2025 Hewlett Packard Enterprise Development LP

--- a/ansible/roles/csm.sbps.apply_label/tasks/main.yml
+++ b/ansible/roles/csm.sbps.apply_label/tasks/main.yml
@@ -28,6 +28,21 @@
 # then all workers belonging to that group will be configured.
 
 #  Add or remove the k8s label on worker nodes to match the HSM group
+- name: Determine intersection of HSM iSCSI group and NCN worker nodes
+  # {{groups}} is a variable containing all host groups. CFS creates a host group for every HSM group.
+  when: iscsi_group_name in groups
+  run_once: true
+  delegate_to: localhost
+  set_fact:
+    iscsi_group_has_worker: "{{ groups['Management_Worker'] | intersect(groups[iscsi_group_name]) | length > 0 }}"
+- name: Verify HSM iSCSI group contains at least one worker node
+  # {{groups}} is a variable containing all host groups. CFS creates a host group for every HSM group.
+  when: iscsi_group_name in groups
+  delegate_to: localhost
+  ansible.builtin.assert:
+    that: iscsi_group_has_worker
+    fail_msg: "HSM group \"{{iscsi_group_name}}\" contains no worker NCNs"
+    success_msg: "HSM group \"{{iscsi_group_name}}\" contains at least 1 worker NCN"
 - name: Get Kubernetes node info
   kubernetes.core.k8s_info:
     api_version: v1

--- a/ansible/roles/csm.sbps.apply_label/tasks/main.yml
+++ b/ansible/roles/csm.sbps.apply_label/tasks/main.yml
@@ -27,52 +27,36 @@
 # the HSM group defined below (under iscsi_group_name) exists. If that HSM group exists,
 # then all workers belonging to that group will be configured.
 
+# {{groups}} is a variable containing all host groups. CFS creates a host group for every HSM group.
+# {{group_names}} is a list of host groups to which the current host belongs.
+
 #  Add or remove the k8s label on worker nodes to match the HSM group
-- name: Determine intersection of HSM iSCSI group and NCN worker nodes
-  # {{groups}} is a variable containing all host groups. CFS creates a host group for every HSM group.
-  when: iscsi_group_name in groups
+- name: All workers are intended for iSCSI by default
   run_once: true
   delegate_to: localhost
   set_fact:
-    iscsi_group_has_worker: "{{ groups['Management_Worker'] | intersect(groups[iscsi_group_name]) | length > 0 }}"
-- name: Verify HSM iSCSI group contains at least one worker node
-  # {{groups}} is a variable containing all host groups. CFS creates a host group for every HSM group.
-  when: iscsi_group_name in groups
+    iscsi_workers: "{{ groups['Management_Worker'] }}"
+
+- name: Only workers in HSM group are intended for iSCSI
+  run_once: true
   delegate_to: localhost
+  set_fact:
+    # Overwrite the fact from the previous step with the intersection of itself and the HSM group
+    iscsi_workers: "{{ groups[iscsi_group_name] | intersect(iscsi_workers) }}"
+  when: iscsi_group_name in groups
+
+- name: Verify HSM iSCSI group contains at least one worker node
+  run_once: true
+  delegate_to: localhost
+  when: iscsi_group_name in groups
   ansible.builtin.assert:
-    that: iscsi_group_has_worker
+    that: iscsi_workers | length > 0
     fail_msg: "HSM group \"{{iscsi_group_name}}\" contains no worker NCNs"
     success_msg: "HSM group \"{{iscsi_group_name}}\" contains at least 1 worker NCN"
-- name: Get Kubernetes node info
-  kubernetes.core.k8s_info:
-    api_version: v1
-    kind: Node
-    name: "{{ansible_hostname}}"
-  register: node_info
-  failed_when: node_info.resources is not defined or node_info.resources | length == 0
-- name: Check iSCSI label and HSM group
-  set_fact:
-    has_iscsi_label: "{{ 'iscsi' in node_info.resources[0].metadata.labels and node_info.resources[0].metadata.labels['iscsi'] == iscsi_label_value }}"
-    # {{groups}} is a variable containing all host groups. CFS creates a host group for every HSM group.
-    # {{group_names}} is a list of host groups to which the current host belongs.
-    intended_for_iscsi: "{{ (iscsi_group_name not in groups) or (iscsi_group_name in group_names) }}"
-- name: Add label
-  kubernetes.core.k8s:
-    api_version: v1
-    kind: Node
-    name: "{{ansible_hostname}}"
-    definition:
-      metadata:
-        labels:
-          iscsi: "{{iscsi_label_value}}"
-  when: intended_for_iscsi and not has_iscsi_label
-- name: Remove label
-  kubernetes.core.k8s:
-    api_version: v1
-    kind: Node
-    name: "{{ansible_hostname}}"
-    definition:
-      metadata:
-        labels:
-          iscsi: null
-  when: not intended_for_iscsi and has_iscsi_label
+
+- name: Update labels
+  ansible.builtin.include_tasks:
+    file: update_labels.yml
+  loop: "{{ groups['Management_Worker'] }}"
+  loop_control:
+    loop_var: xname

--- a/ansible/roles/csm.sbps.apply_label/tasks/update_labels.yml
+++ b/ansible/roles/csm.sbps.apply_label/tasks/update_labels.yml
@@ -1,0 +1,98 @@
+#
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+---
+
+# This list of tasks is called from main.yml in a loop
+# The loop variable is {{xname}} and contains the xname of the worker node to check
+# This also requires that the {{iscsi_workers}} workers variable has been set in main.yml to
+# the list of all worker NCN xnames
+
+- name: "Get SLS data for {{xname}}"
+  delegate_to: localhost
+  run_once: true
+  uri:
+    url: "{{ 'http://cray-sls/v1/hardware/' + xname }}"
+    return_content: true
+    method: GET
+  register: _api_result
+
+- name: "Set worker hostname list for {{xname}}"
+  delegate_to: localhost
+  run_once: true
+  set_fact:
+    worker_hostnames: "{{ _api_result.json.ExtraProperties.Aliases | select('search', '^ncn-w[0-9]{3}$') }}"
+
+- name: "Verify a worker hostname was found for {{xname}}"
+  delegate_to: localhost
+  run_once: true
+  ansible.builtin.assert:
+    that: worker_hostnames | length > 0
+    fail_msg: "No ncn-w### hostname found for {{ xname }}"
+    success_msg: "Found ncn-w### hostname for {{ xname }}"
+
+- name: "Get Kubernetes node info for {{xname}} / {{worker_hostnames[0]}}"
+  delegate_to: localhost
+  run_once: true
+  kubernetes.core.k8s_info:
+    api_version: v1
+    api_key: "{{ lookup('ansible.builtin.file', '/run/secrets/kubernetes.io/serviceaccount/token') }}"
+    kind: Node
+    name: "{{worker_hostnames[0]}}"
+  register: _node_info
+  failed_when: _node_info.resources is not defined or _node_info.resources | length == 0
+
+- name: "Check iSCSI label and HSM group for {{xname}} / {{worker_hostnames[0]}}"
+  delegate_to: localhost
+  run_once: true
+  set_fact:
+    _has_iscsi_label: "{{ 'iscsi' in _node_info.resources[0].metadata.labels and _node_info.resources[0].metadata.labels['iscsi'] == iscsi_label_value }}"
+    _intended_for_iscsi: "{{ xname in iscsi_workers }}"
+
+- name: "Add label to {{xname}} / {{worker_hostnames[0]}}"
+  delegate_to: localhost
+  run_once: true
+  kubernetes.core.k8s:
+    api_version: v1
+    api_key: "{{ lookup('ansible.builtin.file', '/run/secrets/kubernetes.io/serviceaccount/token') }}"
+    kind: Node
+    name: "{{worker_hostnames[0]}}"
+    definition:
+      metadata:
+        labels:
+          iscsi: "{{iscsi_label_value}}"
+  when: _intended_for_iscsi and not _has_iscsi_label
+
+- name: "Remove label from {{xname}} / {{worker_hostnames[0]}}"
+  delegate_to: localhost
+  run_once: true
+  kubernetes.core.k8s:
+    api_version: v1
+    api_key: "{{ lookup('ansible.builtin.file', '/run/secrets/kubernetes.io/serviceaccount/token') }}"
+    kind: Node
+    name: "{{worker_hostnames[0]}}"
+    definition:
+      metadata:
+        labels:
+          iscsi: null
+  when: not _intended_for_iscsi and _has_iscsi_label


### PR DESCRIPTION
## [CASMPET-7625](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7625): Update labels for all workers whether or not they are running

Currently, the apply_labels step does its execution on the target worker NCN. This means that for workers that are down, it will not change their labels.

This PR changes it so that the apply_labels role runs locally inside the CFS pod. Additionally, it will update the labels for all workers, whether or not they are up when the play runs, or even if they are not one of the hosts targeted for the play. Basically, any time this role runs, it sets/removes the Kubernetes tags for all of the workers.

For the good path (where all nodes are up), there will be no change in the ultimate behavior of the play (although the CFS logs will look different).

An example of the new role running:

```
TASK [csm.sbps.apply_label : All workers are intended for iSCSI by default] ****
ok: [x3000c0s11b0n0 -> localhost]

TASK [csm.sbps.apply_label : Update labels] ************************************
included: /etc/ansible/layer1/roles/csm.sbps.apply_label/tasks/update_labels.yml for x3000c0s11b0n0, x3000c0s26b0n0, x3000c0s7b0n0, x3000c0s9b0n0 => (item=x3000c0s11b0n0)
included: /etc/ansible/layer1/roles/csm.sbps.apply_label/tasks/update_labels.yml for x3000c0s11b0n0, x3000c0s26b0n0, x3000c0s7b0n0, x3000c0s9b0n0 => (item=x3000c0s26b0n0)
included: /etc/ansible/layer1/roles/csm.sbps.apply_label/tasks/update_labels.yml for x3000c0s11b0n0, x3000c0s26b0n0, x3000c0s7b0n0, x3000c0s9b0n0 => (item=x3000c0s7b0n0)
included: /etc/ansible/layer1/roles/csm.sbps.apply_label/tasks/update_labels.yml for x3000c0s11b0n0, x3000c0s26b0n0, x3000c0s7b0n0, x3000c0s9b0n0 => (item=x3000c0s9b0n0)

TASK [csm.sbps.apply_label : Get SLS data for x3000c0s11b0n0] ******************
ok: [x3000c0s11b0n0 -> localhost]

TASK [csm.sbps.apply_label : Set worker hostname list for x3000c0s11b0n0] ******
ok: [x3000c0s11b0n0 -> localhost]

TASK [csm.sbps.apply_label : Verify a worker hostname was found for x3000c0s11b0n0] ***
ok: [x3000c0s11b0n0 -> localhost] => {
    "changed": false,
    "msg": "Found ncn-w### hostname for x3000c0s11b0n0"
}

TASK [csm.sbps.apply_label : Get Kubernetes node info for x3000c0s11b0n0 / ncn-w003] ***
ok: [x3000c0s11b0n0 -> localhost]

TASK [csm.sbps.apply_label : Check iSCSI label and HSM group for x3000c0s11b0n0 / ncn-w003] ***
ok: [x3000c0s11b0n0 -> localhost]

TASK [csm.sbps.apply_label : Add label to x3000c0s11b0n0 / ncn-w003] ***********
changed: [x3000c0s11b0n0 -> localhost]

TASK [csm.sbps.apply_label : Get SLS data for x3000c0s26b0n0] ******************
ok: [x3000c0s11b0n0 -> localhost]

TASK [csm.sbps.apply_label : Set worker hostname list for x3000c0s26b0n0] ******
ok: [x3000c0s11b0n0 -> localhost]

TASK [csm.sbps.apply_label : Verify a worker hostname was found for x3000c0s26b0n0] ***
ok: [x3000c0s11b0n0 -> localhost] => {
    "changed": false,
    "msg": "Found ncn-w### hostname for x3000c0s26b0n0"
}

TASK [csm.sbps.apply_label : Get Kubernetes node info for x3000c0s26b0n0 / ncn-w004] ***
ok: [x3000c0s11b0n0 -> localhost]

TASK [csm.sbps.apply_label : Check iSCSI label and HSM group for x3000c0s26b0n0 / ncn-w004] ***
ok: [x3000c0s11b0n0 -> localhost]

TASK [csm.sbps.apply_label : Get SLS data for x3000c0s7b0n0] *******************
ok: [x3000c0s11b0n0 -> localhost]

TASK [csm.sbps.apply_label : Set worker hostname list for x3000c0s7b0n0] *******
ok: [x3000c0s11b0n0 -> localhost]

TASK [csm.sbps.apply_label : Verify a worker hostname was found for x3000c0s7b0n0] ***
ok: [x3000c0s11b0n0 -> localhost] => {
    "changed": false,
    "msg": "Found ncn-w### hostname for x3000c0s7b0n0"
}

TASK [csm.sbps.apply_label : Get Kubernetes node info for x3000c0s7b0n0 / ncn-w001] ***
ok: [x3000c0s11b0n0 -> localhost]

TASK [csm.sbps.apply_label : Check iSCSI label and HSM group for x3000c0s7b0n0 / ncn-w001] ***
ok: [x3000c0s11b0n0 -> localhost]

TASK [csm.sbps.apply_label : Add label to x3000c0s7b0n0 / ncn-w001] ************
changed: [x3000c0s11b0n0 -> localhost]

TASK [csm.sbps.apply_label : Get SLS data for x3000c0s9b0n0] *******************
ok: [x3000c0s11b0n0 -> localhost]

TASK [csm.sbps.apply_label : Set worker hostname list for x3000c0s9b0n0] *******
ok: [x3000c0s11b0n0 -> localhost]

TASK [csm.sbps.apply_label : Verify a worker hostname was found for x3000c0s9b0n0] ***
ok: [x3000c0s11b0n0 -> localhost] => {
    "changed": false,
    "msg": "Found ncn-w### hostname for x3000c0s9b0n0"
}

TASK [csm.sbps.apply_label : Get Kubernetes node info for x3000c0s9b0n0 / ncn-w002] ***
ok: [x3000c0s11b0n0 -> localhost]

TASK [csm.sbps.apply_label : Check iSCSI label and HSM group for x3000c0s9b0n0 / ncn-w002] ***
ok: [x3000c0s11b0n0 -> localhost]
```

## [CASMPET-7624](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7624): Immediately fail iSCSI playbook if HSM group is in bad state

If the iSCSI HSM group exists but contains no worker nodes, this means that iSCSI will be enabled on no workers. This in turn means that no compute nodes can boot. Because of this, it is not really a supported situation. Currently the iSCSI playbook fails because of this, but it does so on the very last role, and in a way that does not make the cause of the failure obvious.

This PR adds a check to the very beginning of the apply label role. This check only runs if the HSM group exists. If it does, it generates the intersection of the HSM group and the NCN worker nodes, and determines its length. If that length is 0, then the playbook is failed for all workers, with an appropriate error message printed.

Before this PR, the failure message looked like this:
```
TASK [csm.sbps.dns_srv_records : Create DNS "SRV" and "A" records of HSN and NMN for each worker node] ***
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: NoneType: None
fatal: [x3000c0s11b0n0 -> x3000c0s11b0n0]: FAILED! => {"changed": false, "msg": "non-zero return code", "rc": 22, "stderr": "Shared connection to x3000c0s11b0n0 closed.\r\n", "stderr_lines": ["Shared conn                                                                                  ection to x3000c0s11b0n0 closed."], "stdout": "", "stdout_lines": []}
```

With my changes, the failure message looks like:
```
TASK [csm.sbps.apply_label : Verify HSM iSCSI group contains at least one worker node] ***
fatal: [x3000c0s11b0n0 -> localhost]: FAILED! => {
    "assertion": "iscsi_workers | length > 0",
    "changed": false,
    "evaluated_to": false,
    "msg": "HSM group \"iscsi_worker\" contains no worker NCNs"
}
```

I tested this on drax and starlord. I tested the case where the group does not exist, where it exists and is empty, where it exists but only contains non-worker NCNs, and where it exists and contains worker NCNs. As expected, the first and last case run without error, and the middle two cases fail with the new error messages shown above.