### PR TITLE
CASMCMS-9512: Remove inappropriate calls to end_play in csm.ssh roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- CASMCMS-9512: Modify the `csm.ssh_config` and `csm.ssh_keys` roles so that they no longer
+  call `end_play` when they are only actually wanting to end the role.
+
 ## [1.46.0] - 2025-08-01
 
 ### Changed

--- a/ansible/roles/csm.ssh_config/tasks/main.yml
+++ b/ansible/roles/csm.ssh_config/tasks/main.yml
@@ -53,12 +53,9 @@
         ssh_config: ''
         ssh_config_found: false
 
-- name: Determine if play will go on
-  debug: msg="No CSM SSH configuration key exists in Vault for the {{ ssh_config_username }} user. Exiting without error."
-  when: not ssh_config_found
-
-- name: End play if the key does not exist in Vault
-  meta: end_play
+- name: Note that SSH config not found
+  run_once: true
+  debug: msg="No CSM SSH configuration key exists in Vault for the {{ ssh_config_username }} user."
   when: not ssh_config_found
 
 - name: Ensure the user exists
@@ -66,6 +63,7 @@
     name: "{{ ssh_config_username }}"
     state: present
   register: user_registered
+  when: ssh_config_found
 
 - name: Copy the SSH config file
   copy:

--- a/ansible/roles/csm.ssh_keys/tasks/main.yml
+++ b/ansible/roles/csm.ssh_keys/tasks/main.yml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -66,12 +66,9 @@
       set_fact:
         ssh_pub_key: ''
 
-- name: Determine if play will go on
-  debug: msg="Neither a private or public key exist in Vault for the {{ ssh_keys_username }} user. Exiting without error."
-  when: ssh_pub_key == '' and ssh_priv_key == ''
-
-- name: End play if neither key exists in Vault
-  meta: end_play
+- name: Check if either key exists
+  debug: msg="Neither a private or public key exist in Vault for the {{ ssh_keys_username }} user."
+  run_once: true
   when: ssh_pub_key == '' and ssh_priv_key == ''
 
 - name: Ensure the user exists
@@ -79,6 +76,7 @@
     name: "{{ ssh_keys_username }}"
     state: present
   register: user_registered
+  when: ssh_pub_key != '' or ssh_priv_key != ''
 
 - name: Add the public key to the authorized keys file
   authorized_key:
@@ -111,4 +109,3 @@
   become: true
   become_user: "{{ ssh_keys_username }}"
   when: ssh_priv_key != ''
-


### PR DESCRIPTION
`csm.ssh_keys` and `csm.ssh_config` both call `end_play` in the case that no SSH data is found in Vault for the specified user. This causes the entire play to end, but really they just wanted to end the role. There is no `end_role` directive, but some small changes to using `when` conditionals accomplishes the same thing.

I have tested this on `wasp` to verify that it works as expected.