### PR TITLE
CASM-5681 Adding changes for CEPH play to run k8s on ansible and to s…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CASMCMS-9512: Modify the `csm.ssh_config` and `csm.ssh_keys` roles so that they no longer
   call `end_play` when they are only actually wanting to end the role.
 
+## [1.47.0] - 2025-08-12
+
+### Changed
+
+- CASM-5681:
+- Modify `csm.rr.check_enablement` role for following - 
+  - Instead of getting `ceph_prefix` from python script, retrieving it from ansible play directly.
+  - Save the result as an Ansible fact so that can be used by ceph_zoning role.
+- Modify `csm.rr.ceph_zoning` to use the `ceph_prefix` fact that was set above.
+- Modify `csm.rr.ceph_zoning` to run CEPH zoning and haproxy tasks only once. If already run, skip these roles. 
+
 ## [1.46.0] - 2025-08-01
 
 ### Changed
@@ -768,7 +779,9 @@ RR Ansible plays for:
 
 - Ansible playbook for applying csm packages to Compute and Application nodes
 
-[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.46.0...HEAD
+[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.47.0...HEAD
+
+[1.47.0]: https://github.com/Cray-HPE/csm-config/compare/1.46.0...1.47.0
 
 [1.46.0]: https://github.com/Cray-HPE/csm-config/compare/1.45.0...1.46.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - CASM-5681:
-- Modify `csm.rr.check_enablement` role for following - 
-  - Instead of getting `ceph_prefix` from python script, retrieving it from ansible play directly.
-  - Save the result as an Ansible fact so that can be used by ceph_zoning role.
-- Modify `csm.rr.ceph_zoning` to use the `ceph_prefix` fact that was set above.
-- Modify `csm.rr.ceph_zoning` to run CEPH zoning and haproxy tasks only once. If already run, skip these roles. 
+  - Modify `csm.rr.check_enablement` role to set `ceph_prefix` fact from `customizations.yaml`,
+    for use by other roles
+  - Modify `csm.rr.ceph_zoning` to use the `ceph_prefix` fact
+  - Modify `csm.rr.ceph_zoning` to run Ceph zoning and haproxy tasks only once. If already run, skip these roles. 
 
 ## [1.46.1] - 2025-08-12
 

--- a/ansible/roles/csm.rr.ceph_zoning/files/ceph_zoning.py
+++ b/ansible/roles/csm.rr.ceph_zoning/files/ceph_zoning.py
@@ -47,8 +47,10 @@ logger.addHandler(ch)
 def run_command(command: str) -> str:
     """
     Helper function to run a shell command.
-    command: is one of the command from yq, kubectl and ceph
-    Returns result of the command output(stdout).
+    Args:
+        command (str): The shell command to run.
+    Returns:
+        str: The output of the command.
     """
     logger.info(f"Running command: {command}")
     try:
@@ -59,11 +61,15 @@ def run_command(command: str) -> str:
 
 def create_and_map_racks(positions_dict: Dict[str, List[str]], ceph_zone_prefix: str) -> List[int]:
     """
-    Create ceph zones and map to management racks.
-    positions_dict: dict of rack and corresponding management nodes(xnames)
-    fetched from the rack placement file(/tmp/rack_info.txt).
-    Here ceph zone name is: ceph zone prefix  + xname of the rack
-    Return sn_count_in_rack (storage nodes per rack)
+    Creates Ceph racks corresponding to management racks and maps storage nodes to those racks.
+    Args:
+        positions_dict (dict): A dictionary mapping rack names to their corresponding
+            management node xnames. This information is typically retrieved from
+            the rack placement file located at /tmp/rack_info.txt.
+        ceph_zone_prefix (str): A prefix to prepend to each rack name when creating the Ceph zones.
+    Returns:
+        sn_count_in_rack (list): A list representing the number of storage nodes per rack.
+            Example format: [1, 2, 1]
     """
 
     sn_count_in_rack = []
@@ -106,12 +112,16 @@ def create_and_apply_rules() -> None:
 
 def service_zoning(positions_dict: Dict[str, List[str]], sn_count_in_rack: List[int]) -> None:
     """
-    Perform service((MON, MGR, MDS) zoning.
-    positions_dict: dict of rack and corresponding management nodes(xnames)
-    fetched from the rack placement file(/tmp/rack_info.txt).
-    sn_count_in_rack: number of storage nodes in a rack.
+    Perform CEPH services(MON, MGR, MDS) zoning.
     Apply service zoning only if minimum 3 racks with storage nodes (at least one per rack) are present.
-    Return nothing.
+    Args:
+    positions_dict (dict): A dictionary mapping rack names to their corresponding
+        management node xnames. This information is typically retrieved from
+        the rack placement file located at /tmp/rack_info.txt.
+    sn_count_in_rack (list): A list representing the number of storage nodes per rack.
+        Example format: [1, 2, 1]
+    Returns:
+    None
     """
     service_node_list = []
     remaining_service_node_list = []
@@ -195,6 +205,7 @@ def main() -> None:
     as the failure domain and perform ceph service zoning.
     rack_placement_file is a file with key value pair with xnames of
     racks and corresponding management nodes.
+    ceph_prefix is a prefix to prepend to each rack name when creating the Ceph zones.
     """
     if len(sys.argv) not in {2, 3}:
         logger.error("Usage: python ceph_zoning.py <rack_placement_file> [ceph_prefix]")

--- a/ansible/roles/csm.rr.ceph_zoning/files/ceph_zoning.py
+++ b/ansible/roles/csm.rr.ceph_zoning/files/ceph_zoning.py
@@ -196,7 +196,7 @@ def main() -> None:
     rack_placement_file is a file with key value pair with xnames of
     racks and corresponding management nodes.
     """
-    if len(sys.argv) < 2:
+    if len(sys.argv) not in {2, 3}:
         logger.error("Usage: python ceph_zoning.py <rack_placement_file> [ceph_prefix]")
         sys.exit(1)
 
@@ -212,6 +212,8 @@ def main() -> None:
     ceph_prefix = sys.argv[2] if len(sys.argv) > 2 else ""
     if ceph_prefix:
         logger.info(f"Using ceph prefix: {ceph_prefix}")
+    else:
+        logger.info("No ceph prefix specified")
     # Create and map racks, create rules, and perform service zoning
     sn_count_in_rack = create_and_map_racks(positions_dict, ceph_prefix)
     create_and_apply_rules()

--- a/ansible/roles/csm.rr.ceph_zoning/files/ceph_zoning.py
+++ b/ansible/roles/csm.rr.ceph_zoning/files/ceph_zoning.py
@@ -57,7 +57,7 @@ def run_command(command: str) -> str:
         raise ValueError(f"Command {command} errored out with : {e.stderr}") from e
     return result.stdout
 
-def create_and_map_racks(positions_dict: Dict[str, List[str]], ceph_zone_prefix: str) -> list:
+def create_and_map_racks(positions_dict: Dict[str, List[str]], ceph_zone_prefix: str) -> List[int]:
     """
     Create ceph zones and map to management racks.
     positions_dict: dict of rack and corresponding management nodes(xnames)
@@ -104,7 +104,7 @@ def create_and_apply_rules() -> None:
         logger.debug(f"Applying new rule to pool: {pool}")
         run_command(f"ceph osd pool set {pool} crush_rule replicated_rule_with_rack_failure_domain")
 
-def service_zoning(positions_dict: Dict[str, List[str]], sn_count_in_rack: list) -> None:
+def service_zoning(positions_dict: Dict[str, List[str]], sn_count_in_rack: List[int]) -> None:
     """
     Perform service((MON, MGR, MDS) zoning.
     positions_dict: dict of rack and corresponding management nodes(xnames)

--- a/ansible/roles/csm.rr.ceph_zoning/tasks/main.yml
+++ b/ansible/roles/csm.rr.ceph_zoning/tasks/main.yml
@@ -24,15 +24,40 @@
 ---
 # Apply CEPH zoning to make sure CEPH data gets replicated at rack level, 
 # so that there would not be data loss incase of a rack failure.
+
+- name: Check if CEPH rack entries with assigned children exist
+  shell: |
+    ceph osd tree -f json | jq -r '.nodes[] | select(.type == "rack" and (.children | length > 0)) | .name'
+  register: rack_check
+  delegate_to: "{{ play_hosts | first }}"
+  run_once: true
+  changed_when: false
+
+- name: Debug message when CEPH racks with children exist
+  when: rack_check.stdout_lines | length > 0
+  debug:
+    msg: "Racks already exist in CEPH OSD tree. Skipping CEPH zoning and CEPH haproxy reconfiguration"
+  run_once: true
+
+- name: Skipping CEPH zoning and CEPH haproxy reconfiguration since its already applied
+  meta: end_play
+  when: rack_check.stdout_lines | length > 0
+  run_once: true
+
 - name: Check for mgmt nodes placement discovery file
   stat:
     path: "/tmp/rack_info.txt"
   register: placement_file
   delegate_to: "{{ play_hosts | first }}"
   run_once: true
+  changed_when: false
+
+- name: Debug ceph_prefix
+  debug:
+    var: ceph_prefix
 
 - name: Apply CEPH zoning
-  script: ceph_zoning.py /tmp/rack_info.txt
+  script: "ceph_zoning.py /tmp/rack_info.txt '{{ ceph_prefix | default('') }}'"
   args:
     executable: python3
   when: placement_file.stat.exists

--- a/ansible/roles/csm.rr.ceph_zoning/tasks/main.yml
+++ b/ansible/roles/csm.rr.ceph_zoning/tasks/main.yml
@@ -25,25 +25,6 @@
 # Apply CEPH zoning to make sure CEPH data gets replicated at rack level, 
 # so that there would not be data loss incase of a rack failure.
 
-- name: Check if CEPH rack entries with assigned children exist
-  shell: |
-    ceph osd tree -f json | jq -r '.nodes[] | select(.type == "rack" and (.children | length > 0)) | .name'
-  register: rack_check
-  delegate_to: "{{ play_hosts | first }}"
-  run_once: true
-  changed_when: false
-
-- name: Debug message when CEPH racks with children exist
-  when: rack_check.stdout_lines | length > 0
-  debug:
-    msg: "Racks already exist in CEPH OSD tree. Skipping CEPH zoning and CEPH haproxy reconfiguration"
-  run_once: true
-
-- name: Skipping CEPH zoning and CEPH haproxy reconfiguration since its already applied
-  meta: end_play
-  when: rack_check.stdout_lines | length > 0
-  run_once: true
-
 - name: Check for mgmt nodes placement discovery file
   stat:
     path: "/tmp/rack_info.txt"

--- a/ansible/roles/csm.rr.check_enablement/tasks/check.yml
+++ b/ansible/roles/csm.rr.check_enablement/tasks/check.yml
@@ -90,10 +90,12 @@
 - name: Set ceph_prefix variable
   delegate_to: localhost
   run_once: true
+  when: rr_enabled
   set_fact:
     ceph_prefix: "{{ customizations_yaml.spec.kubernetes.services['rack-resiliency'].ceph_zone_prefix | default('') }}"
 
 - name: Show ceph_prefix value
+  when: rr_enabled
   debug:
     var: ceph_prefix
 

--- a/ansible/roles/csm.rr.check_enablement/tasks/check.yml
+++ b/ansible/roles/csm.rr.check_enablement/tasks/check.yml
@@ -86,3 +86,14 @@
   when: (rr_enabled is not defined) or (rr_enabled not in [true, false])
   set_fact:
     rr_enabled: "{{ customizations_yaml.spec.kubernetes.services['rack-resiliency'].enabled | bool }}"
+
+- name: Set ceph_prefix variable
+  delegate_to: localhost
+  run_once: true
+  set_fact:
+    ceph_prefix: "{{ customizations_yaml.spec.kubernetes.services['rack-resiliency'].ceph_zone_prefix | default('') }}"
+
+- name: Show ceph_prefix value
+  debug:
+    var: ceph_prefix
+


### PR DESCRIPTION
…kip multiple applications of the play

## Summary and Scope

For the issue - 
CASM-5681 RR storage play assumes kubectl configured on all storage nodes

Added changes for CEPH play to run k8s command on ansible directly instead of hosts since storage nodes other than s001/s002/s003 would not be having k8s config file which makes kubernetes commands to fail.

And also, added additional logic to skip multiple applications of the play to avoid further issues.

## Issues and Related PRs

* Resolves [CASM-5681](https://jira-pro.it.hpe.com:8443/browse/CASM-5681)

## Testing

### Tested on:

  * `odin`

### Test description:

Tested component update using cfs on Odin. 
Case 1 - CEPH zoning is not present on the system. Modified RR layer with the latest changes and applied it on ncn-s003. CEPH zoning got applied successfully.
https://ara.cmn.odin.hpc.amslabs.hpecorp.net/playbooks/20218.html

Case 2 - With case 1, CEPH zoning is present on the system. Applied the same RR layer on ncn-s002. CEPH zoning is skipped as expected.
https://ara.cmn.odin.hpc.amslabs.hpecorp.net/playbooks/20224.html

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

