### PR TITLE
CASM-5685: RR storage play still assumes kubectl configured on all storage nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.48.0] - 2025-08-15
+
+### Fixed
+
+- CASM-5685: RR storage play still assumes kubectl configured on all storage nodes
+  - Fixed csm.rr.mgmt_nodes_placement_discovery role to use native Ansible (for kubectl) inside the
+    CFS pod to get the information from Kubernetes instead of getting it from the node directly.
+
 ## [1.47.0] - 2025-08-14
 
 ### Changed
@@ -791,7 +799,9 @@ RR Ansible plays for:
 
 - Ansible playbook for applying csm packages to Compute and Application nodes
 
-[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.47.0...HEAD
+[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.48.0...HEAD
+
+[1.48.0]: https://github.com/Cray-HPE/csm-config/compare/1.47.0...1.48.0
 
 [1.47.0]: https://github.com/Cray-HPE/csm-config/compare/1.46.1...1.47.0
 

--- a/ansible/roles/csm.rr.mgmt_nodes_placement_discovery/files/rack_to_node_mapping.py
+++ b/ansible/roles/csm.rr.mgmt_nodes_placement_discovery/files/rack_to_node_mapping.py
@@ -41,7 +41,7 @@ import requests
 hsm_url = "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components"
 sls_url= "https://api-gw-service-nmn.local/apis/sls/v1/search/hardware"
 
-# Get the secret
+# Get the authentication token
 def token_fetch(client_secret: str) -> Union[str, None]:
     """
     Fetch the keycloak token.

--- a/ansible/roles/csm.rr.mgmt_nodes_placement_discovery/files/rack_to_node_mapping.py
+++ b/ansible/roles/csm.rr.mgmt_nodes_placement_discovery/files/rack_to_node_mapping.py
@@ -41,7 +41,7 @@ import requests
 hsm_url = "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components"
 sls_url= "https://api-gw-service-nmn.local/apis/sls/v1/search/hardware"
 
-# Run the kubectl command to get the secret
+# Get the secret
 def token_fetch(client_secret: str) -> Union[str, None]:
     """
     Fetch the keycloak token.

--- a/ansible/roles/csm.rr.mgmt_nodes_placement_discovery/files/rack_to_node_mapping.py
+++ b/ansible/roles/csm.rr.mgmt_nodes_placement_discovery/files/rack_to_node_mapping.py
@@ -42,30 +42,12 @@ hsm_url = "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components"
 sls_url= "https://api-gw-service-nmn.local/apis/sls/v1/search/hardware"
 
 # Run the kubectl command to get the secret
-def token_fetch() -> Union[str, None]:
+def token_fetch(client_secret: str) -> Union[str, None]:
     """
     Fetch the keycloak token.
     Return keycloak token.
     """
     response = None
-
-    try:
-        result = subprocess.run(
-            ["kubectl", "get", "secrets", "admin-client-auth", "-o", "jsonpath={.data.client-secret}"],
-            stdout=subprocess.PIPE,  # Capture stdout
-            stderr=subprocess.PIPE,  # Capture stderr
-            universal_newlines=True,  # Use text mode for output decoding
-            check=True,  # Will raise an exception if the command fails
-        )
-        # If the command was successful, result will be a CompletedProcess object
-        client_secret = base64.b64decode(result.stdout.strip()).decode('utf-8')
-
-    except subprocess.CalledProcessError as e:
-        print(f"Error occurred while running kubectl: {e.stderr}")
-        sys.exit(1)
-    except Exception as e:
-        print(f"Unexpected error: {str(e)}")
-        sys.exit(1)
 
     # Set up the parameters and URL to make the POST request
     url = "https://api-gw-service-nmn.local/keycloak/realms/shasta/protocol/openid-connect/token"
@@ -125,8 +107,13 @@ def main() -> None:
     info (xnames in the form of key value pair) from HSM and SLS and store it under
     /tmp/rack_info.txt file to be consumed by zoning(k8s and ceph) functions.
     """
+    if len(sys.argv) != 2:
+       logger.error("Usage: python3 rack_to_node_mapping.py <client_secret> ")
+       sys.exit(1)
+
     # Fetch the keycloak token
-    token = token_fetch()
+    client_secret = sys.argv[1]
+    token = token_fetch(client_secret)
     if token is None:
         print("Failed to get the keycloak token")
         sys.exit(1)

--- a/ansible/roles/csm.rr.mgmt_nodes_placement_discovery/tasks/main.yml
+++ b/ansible/roles/csm.rr.mgmt_nodes_placement_discovery/tasks/main.yml
@@ -25,8 +25,38 @@
 
 # Discover physical racks and their mapping with respective management nodes
 # placement from HSM/ SLS 
+- name: Get site-init secret
+  delegate_to: localhost
+  run_once: true
+  kubernetes.core.k8s_info:
+    api_version: v1
+    api_key: "{{ lookup('ansible.builtin.file', '/run/secrets/kubernetes.io/serviceaccount/token') }}"
+    kind: Secret
+    name: "admin-client-auth"
+    namespace: "default"
+  register: _sec
+  failed_when: (_sec.resources is not defined) or (_sec.resources | length == 0)
+
+- name: Verify secret has data field
+  delegate_to: localhost
+  run_once: true
+  ansible.builtin.assert:
+    that: "{{ 'data' in _sec.resources[0] }}"
+
+- name: Verify that data has client-secret field
+  delegate_to: localhost
+  run_once: true
+  ansible.builtin.assert:
+    that: "{{ 'client-secret' in _sec.resources[0].data }}"
+
+- name: Decode client-secret
+  delegate_to: localhost
+  run_once: true
+  set_fact:
+    client_secret: "{{ _sec.resources[0].data['client-secret'] | b64decode | from_yaml }}"
+
 - name: Discover racks and corresponding management nodes placement
-  script: rack_to_node_mapping.py
+  script: rack_to_node_mapping.py '{{ client_secret }}'
   args:
     executable: python3
   register: mgmt_nodes_discovery

--- a/ansible/roles/csm.rr.mgmt_nodes_placement_discovery/tasks/main.yml
+++ b/ansible/roles/csm.rr.mgmt_nodes_placement_discovery/tasks/main.yml
@@ -52,6 +52,7 @@
 - name: Decode client-secret
   delegate_to: localhost
   run_once: true
+  no_log: true
   set_fact:
     client_secret: "{{ _sec.resources[0].data['client-secret'] | b64decode | from_yaml }}"
 

--- a/ansible/roles/csm.rr.mgmt_nodes_placement_discovery/tasks/main.yml
+++ b/ansible/roles/csm.rr.mgmt_nodes_placement_discovery/tasks/main.yml
@@ -25,7 +25,7 @@
 
 # Discover physical racks and their mapping with respective management nodes
 # placement from HSM/ SLS 
-- name: Get site-init secret
+- name: Get admin-client-auth secret
   delegate_to: localhost
   run_once: true
   kubernetes.core.k8s_info:


### PR DESCRIPTION
## Summary and Scope

[CASM-5685](https://jira-pro.it.hpe.com:8443/browse/CASM-5685): RR storage play still assumes kubectl configured on all storage nodes

The csm.rr.mgmt_nodes_placement_discovery role uses kubectl command to run on the management nodes to get Kubernetes info and that needs to change to use native Ansible inside the CFS pod to get the information from Kubernetes in order to avoid any failures on management nodes (Master and Storage nodes) which are not configured with kubectl.

## Issues and Related PRs

[CASM-5685](https://jira-pro.it.hpe.com:8443/browse/CASM-5685)

## Testing

### Tested on:

Wasp bare metal.

### Test description:


Tested Ansible plays deployments with CFS.

**Verifying on Storage nodes:**

Fanta has only 3 storage nodes as below. We have tested CFS to make it runs on storage node-3 (mention of XNAME during management rollout) and it has been successful.

| x3000c0s13b0n0 | ncn-s001  | Node | 100007 | Ready     | OK   | True    | X86  | River | Management | Storage | Sling    | management-csm-1.6.2 | configured           | 0           | stable      | MISSING                                | MISSING                              |
| x3000c0s15b0n0 | ncn-s002  | Node | 100008 | Ready     | OK   | True    | X86  | River | Management | Storage | Sling    | management-csm-1.6.2 | configured           | 0           | stable      | MISSING                                | MISSING                              |
| x3000c0s17b0n0 | ncn-s003  | Node | 100009 | Ready     | OK   | True    | X86  | River | Management | Storage | Sling    | management-csm-1.6.2 | configured           | 0           | stable      | MISSING                                | MISSING                              |

PLAY RECAP *********************************************************************
 
Running rack_resiliency_for_mgmt_nodes.yml from repo https://api-gw-service-nmn.local/vcs/cray/csm-config-management.git
[WARNING]: Could not match supplied host pattern, ignoring: cfs_image
 
PLAY [Management_Master:!cfs_image] ********************************************
skipping: no hosts matched
 
PLAY [Management_Storage:!cfs_image] *******************************************
 
TASK [csm.rr.mgmt_nodes_placement_discovery : Discover racks and corresponding management nodes placement] ***
changed: [x3000c0s7b0n0 -> x3000c0s7b0n0]
 
PLAY RECAP *********************************************************************
x3000c0s7b0n0              : ok=5    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
 
All playbooks completed successfully
ncn-m001:/etc/cray/upgrade/csm #


**Verifying on Master nodes:**

ncn-m001:~/sav/csm-config-management # kubectl logs -n services "${CFS_POD_NAME}" ansible
'/etc/pki/trust/anchors/46Rvw3.certificate_authority.crt' -> '/etc/cray/ca/certificate_authority.crt'
Inventory generation completed
SSH keys migrated to /root/.ssh
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
HTTP/1.1 200 OK
content-type: text/html; charset=UTF-8
cache-control: no-cache, max-age=0
x-content-type-options: nosniff
date: Fri, 15 Aug 2025 06:24:06 GMT
server: envoy
transfer-encoding: chunked

Sidecar available
Running ncn_nodes.yml from repo https://api-gw-service-nmn.local/vcs/cray/csm-config-management.git

PLAY [Management_Master,Management_Worker,Management_Storage] ******************

TASK [trust-csm-ssh-keys : Inject CSM public Key into SSH authorized_keys file] ***
changed: [x3000c0s3b0n0]

TASK [csm.ca_cert : Run certificate update scripts] ****************************
changed: [x3000c0s3b0n0] => (item={'path': '/usr/lib/ca-certificates/update.d/50java.run', 'mode': '0755', 'isdir': False, 'ischr': False, 'isblk': False, 'isreg': True, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 0, 'gid': 0, 'size': 405, 'inode': 70980, 'dev': 40, 'nlink': 1, 'atime': 1713366010.0, 'mtime': 1713366010.0, 'ctime': 1713366010.0, 'gr_name': 'root', 'pw_name': 'root', 'wusr': True, 'rusr': True, 'xusr': True, 'wgrp': False, 'rgrp': True, 'xgrp': True, 'woth': False, 'roth': True, 'xoth': True, 'isuid': False, 'isgid': False})
changed: [x3000c0s3b0n0] => (item={'path': '/usr/lib/ca-certificates/update.d/70openssl.run', 'mode': '0755', 'isdir': False, 'ischr': False, 'isblk': False, 'isreg': True, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 0, 'gid': 0, 'size': 336, 'inode': 70981, 'dev': 40, 'nlink': 1, 'atime': 1713366010.0, 'mtime': 1713366010.0, 'ctime': 1713366010.0, 'gr_name': 'root', 'pw_name': 'root', 'wusr': True, 'rusr': True, 'xusr': True, 'wgrp': False, 'rgrp': True, 'xgrp': True, 'woth': False, 'roth': True, 'xoth': True, 'isuid': False, 'isgid': False})
changed: [x3000c0s3b0n0] => (item={'path': '/usr/lib/ca-certificates/update.d/80etc_ssl.run', 'mode': '0755', 'isdir': False, 'ischr': False, 'isblk': False, 'isreg': True, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 0, 'gid': 0, 'size': 1868, 'inode': 70982, 'dev': 40, 'nlink': 1, 'atime': 1713366010.0, 'mtime': 1713366010.0, 'ctime': 1713366010.0, 'gr_name': 'root', 'pw_name': 'root', 'wusr': True, 'rusr': True, 'xusr': True, 'wgrp': False, 'rgrp': True, 'xgrp': True, 'woth': False, 'roth': True, 'xoth': True, 'isuid': False, 'isgid': False})
changed: [x3000c0s3b0n0] => (item={'path': '/usr/lib/ca-certificates/update.d/99certbundle.run', 'mode': '0755', 'isdir': False, 'ischr': False, 'isblk': False, 'isreg': True, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 0, 'gid': 0, 'size': 961, 'inode': 70983, 'dev': 40, 'nlink': 1, 'atime': 1713366010.0, 'mtime': 1713366010.0, 'ctime': 1713366010.0, 'gr_name': 'root', 'pw_name': 'root', 'wusr': True, 'rusr': True, 'xusr': True, 'wgrp': False, 'rgrp': True, 'xgrp': True, 'woth': False, 'roth': True, 'xoth': True, 'isuid': False, 'isgid': False})

TASK [passwordless-ssh : Write private keyfile to disk with appropriate permissions] ***
changed: [x3000c0s3b0n0]

TASK [passwordless-ssh : Create the CSM public key file on target hosts] *******
changed: [x3000c0s3b0n0]

TASK [csm.ssh_config : Lookup the SSH config value in Vault] *******************
fatal: [x3000c0s3b0n0 -> localhost]: FAILED! => {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result"}

PLAY [Management_Master,Management_Worker] *************************************

TASK [csm.gpg_keys : include_tasks] ********************************************
included: /etc/ansible/layer0/roles/csm.gpg_keys/tasks/install_key.yml for x3000c0s3b0n0 => (item=(censored due to no_log))
included: /etc/ansible/layer0/roles/csm.gpg_keys/tasks/install_key.yml for x3000c0s3b0n0 => (item=(censored due to no_log))
included: /etc/ansible/layer0/roles/csm.gpg_keys/tasks/install_key.yml for x3000c0s3b0n0 => (item=(censored due to no_log))
included: /etc/ansible/layer0/roles/csm.gpg_keys/tasks/install_key.yml for x3000c0s3b0n0 => (item=(censored due to no_log))
included: /etc/ansible/layer0/roles/csm.gpg_keys/tasks/install_key.yml for x3000c0s3b0n0 => (item=(censored due to no_log))
included: /etc/ansible/layer0/roles/csm.gpg_keys/tasks/install_key.yml for x3000c0s3b0n0 => (item=(censored due to no_log))
included: /etc/ansible/layer0/roles/csm.gpg_keys/tasks/install_key.yml for x3000c0s3b0n0 => (item=(censored due to no_log))
included: /etc/ansible/layer0/roles/csm.gpg_keys/tasks/install_key.yml for x3000c0s3b0n0 => (item=(censored due to no_log))
included: /etc/ansible/layer0/roles/csm.gpg_keys/tasks/install_key.yml for x3000c0s3b0n0 => (item=(censored due to no_log))

TASK [csm.gpg_keys : Create a temporary file to store the key content] *********
changed: [x3000c0s3b0n0]

TASK [csm.gpg_keys : Copy the key content to a temporary file] *****************
changed: [x3000c0s3b0n0]

TASK [csm.gpg_keys : Create a temporary file to store the key content] *********
changed: [x3000c0s3b0n0]

TASK [csm.gpg_keys : Copy the key content to a temporary file] *****************
changed: [x3000c0s3b0n0]

TASK [csm.gpg_keys : Create a temporary file to store the key content] *********
changed: [x3000c0s3b0n0]

TASK [csm.gpg_keys : Copy the key content to a temporary file] *****************
changed: [x3000c0s3b0n0]

TASK [csm.gpg_keys : Create a temporary file to store the key content] *********
changed: [x3000c0s3b0n0]

TASK [csm.gpg_keys : Copy the key content to a temporary file] *****************
changed: [x3000c0s3b0n0]

TASK [csm.gpg_keys : Create a temporary file to store the key content] *********
changed: [x3000c0s3b0n0]

TASK [csm.gpg_keys : Copy the key content to a temporary file] *****************
changed: [x3000c0s3b0n0]

TASK [csm.gpg_keys : Create a temporary file to store the key content] *********
changed: [x3000c0s3b0n0]

TASK [csm.gpg_keys : Copy the key content to a temporary file] *****************
changed: [x3000c0s3b0n0]

TASK [csm.gpg_keys : Create a temporary file to store the key content] *********
changed: [x3000c0s3b0n0]

TASK [csm.gpg_keys : Copy the key content to a temporary file] *****************
changed: [x3000c0s3b0n0]

TASK [csm.gpg_keys : Create a temporary file to store the key content] *********
changed: [x3000c0s3b0n0]

TASK [csm.gpg_keys : Copy the key content to a temporary file] *****************
changed: [x3000c0s3b0n0]

TASK [csm.gpg_keys : Create a temporary file to store the key content] *********
changed: [x3000c0s3b0n0]

TASK [csm.gpg_keys : Copy the key content to a temporary file] *****************
changed: [x3000c0s3b0n0]

TASK [csm.packages : Configure CSM RPM Repos (SLES-based)] *********************
changed: [x3000c0s3b0n0] => (item={'name': 'csm-sle', 'description': 'CSM SLE Packages (added by Ansible)', 'repo': 'https://packages.local/repository/csm-sle-${releasever_major}sp${releasever_minor}'})

TASK [csm.packages : Allow unsigned repo metadata] *****************************
changed: [x3000c0s3b0n0] => (item={'name': 'csm-sle', 'description': 'CSM SLE Packages (added by Ansible)', 'repo': 'https://packages.local/repository/csm-sle-${releasever_major}sp${releasever_minor}'})
changed: [x3000c0s3b0n0] => (item={'name': 'csm-noos', 'description': 'CSM No-OS Packages (added by Ansible)', 'repo': 'https://packages.local/repository/csm-noos'})
changed: [x3000c0s3b0n0] => (item={'name': 'csm-embedded', 'description': 'CSM Embedded NCN Packages (added by Ansible)', 'repo': 'https://packages.local/repository/csm-embedded'})

PLAY [Management_Worker] *******************************************************
skipping: no hosts matched

PLAY [Management_Storage] ******************************************************
skipping: no hosts matched
[WARNING]: Could not match supplied host pattern, ignoring: cfs_image

PLAY [Management_Storage:!cfs_image] *******************************************
skipping: no hosts matched

PLAY RECAP *********************************************************************
x3000c0s3b0n0              : ok=69   changed=24   unreachable=0    failed=0    skipped=3    rescued=1    ignored=0

Running ncn-initrd.yml from repo https://api-gw-service-nmn.local/vcs/cray/csm-config-management.git
[WARNING]: Could not match supplied host pattern, ignoring: cfs_image

PLAY [Management_Master:Management_Worker:Management_Storage:&cfs_image] *******
skipping: no hosts matched

PLAY RECAP *********************************************************************

Running rack_resiliency_for_mgmt_nodes.yml from repo https://api-gw-service-nmn.local/vcs/cray/csm-config-management.git
[WARNING]: Could not match supplied host pattern, ignoring: cfs_image

PLAY [Management_Master:!cfs_image] ********************************************

TASK [csm.rr.mgmt_nodes_placement_discovery : Discover racks and corresponding management nodes placement] ***
changed: [x3000c0s3b0n0 -> x3000c0s3b0n0]

PLAY [Management_Storage:!cfs_image] *******************************************
skipping: no hosts matched

PLAY RECAP *********************************************************************
x3000c0s3b0n0              : ok=6    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0

All playbooks completed successfully
ncn-m001:~/sav/csm-config-management # ssh ncn-m003
...
ncn-m003:~ # cat /tmp/rack_info.txt
{
    "x3000": [
        "ncn-s002",
        "ncn-s003",
        "ncn-m001",
        "ncn-s001",
        "ncn-m003",
        "ncn-w002",
        "ncn-w001",
        "ncn-w003",
        "ncn-m002"
    ]
}
ncn-m003:~ # ls -ltr /tmp/rack_info.txt
-rw-r--r-- 1 root root 204 Aug 15 06:26 /tmp/rack_info.txt
ncn-m003:~ #


_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable