### PR TITLE
CASM-5686: Fix bad-path bugs in rack_to_node_mapping.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- CASM-5686: Fix bad-path bugs in `rack_to_node_mapping.py`
+    - Fix reference to an undefined variable
+    - Validate the format of xnames returned by HSM, to avoid silently generating an invalid or incomplete data file
+    - Check the status code of the SLS response
+    - Check the status codes of the HSM and SLS responses before attempting to JSON decode their bodies
+    - Exit script in error if either request fails, rather than exiting successfully
+    - Add validation to make sure we are getting an alias from SLS that fits the expected format for an NCN
+    - Do not assume there will only be one alias per entry in SLS
+    - Do not assume that the alias we want will be the first one in the entry
+    - Validate that an alias for every NCN is found
+
 ## [1.48.0] - 2025-08-15
 
 ### Fixed

--- a/ansible/roles/csm.rr.mgmt_nodes_placement_discovery/files/rack_to_node_mapping.py
+++ b/ansible/roles/csm.rr.mgmt_nodes_placement_discovery/files/rack_to_node_mapping.py
@@ -28,10 +28,11 @@ Discover physical racks along with corresponding
 management nodes (master, worker and storage).
 """
 
-import json
-import subprocess
-from collections import defaultdict
 import base64
+from collections import defaultdict
+import json
+import re
+import subprocess
 import sys
 from typing import Union
 
@@ -40,6 +41,37 @@ import requests
 # Define the endpoint URL
 hsm_url = "https://api-gw-service-nmn.local/apis/smd/hsm/v2/State/Components"
 sls_url= "https://api-gw-service-nmn.local/apis/sls/v1/search/hardware"
+
+# A partial regular expression for xnames (up through the 'c' character)
+# It has a capture group defined to get the first 5 characters
+xname_regex = re.compile(r'^(x[0-9]{4})c')
+
+# Building blocks for NCN name regular expression
+# These numeric blocks are defined because the NCN number must have a non-0 digit in it.
+
+# First number is non-0
+ncn_num_1 = r'[1-9][0-9]{2}'
+# Second number is non-0
+ncn_num_2 = r'0[1-9][0-9]'
+# Third number is non-0
+ncn_num_3 = r'00[1-9]'
+
+# A regular expression for management NCN aliases that are found in SLS
+# Non-capturing group defined, because if it matches, we want the entire string anyway
+# This is split up across multiple lines for improved human readability
+ncn_regex = re.compile(
+    r'^ncn-[msw]' + r'(?:' + \
+        ncn_num_1 + r'|' + ncn_num_2 + r'|' + ncn_num_3 + \
+    r')$'
+)
+
+def print_stderr(msg: str) -> None:
+    """
+    Prints the specified message to stderr (with a newline appended),
+    and then flushes stderr.
+    """
+    sys.stderr.write(f"{msg}\n")
+    sys.stderr.flush()
 
 # Get the authentication token
 def token_fetch(client_secret: str) -> Union[str, None]:
@@ -65,41 +97,55 @@ def token_fetch(client_secret: str) -> Union[str, None]:
     token = token.get("access_token")
     return token
 
-def rack_info(hsm_response: requests.Response, sls_response: requests.Response) -> None:
+def rack_info(hsm_data: dict, sls_data: dict) -> None:
     """
     Get/ extract  management racks and corresponding management nodes (master, worker and storage)
     from HSM and SLS.
-    hsm_response: Response for GET request to HSM endpoint
-    sls_response: Response for GET request to SLS endpoint
+    hsm_data: Decoded response body from GET request to HSM endpoint
+    sls_data: Decoded response body from GET request to SLS endpoint
     Group and write rack to management nodes mapping into to file /tmp/rack_info.txt, to be consumed
     by zoning functions (k8s and ceph).
     Returns nothing.
     """
-    # Convert the hsm and sls data into json format
-    hsm_data = hsm_response.json()
-    sls_data = sls_response.json()
 
-    # Check the response status and print the JSON output
-    if hsm_response.status_code == 200:
-        filtered_data = [component for component in hsm_data["Components"] if component.get("Role") == "Management" and component.get("SubRole") == "Master" or component.get("SubRole") == "Worker" or component.get("SubRole") == "Storage"]
+    component_ids = [
+        component['ID'] for component in hsm_data["Components"]
+        if component.get("Role") == "Management" and component.get("SubRole") in {"Master", "Worker", "Storage"}
+    ]
 
-         # Group by rack ID (extracted from "ID")
-        res_rack = defaultdict(list)
+    # Group by rack ID (extracted from "ID")
+    res_rack = defaultdict(list)
 
-        for component in filtered_data:
-            rack_id = component["ID"].split("c")[0]  # Extract "x3000" from "x3000c0s1b75n75"
-            for sls_entry in sls_data:
-                if sls_entry["Xname"] == component["ID"]:
-                    aliases = sls_entry["ExtraProperties"]["Aliases"][0]
-                    res_rack[rack_id].append(aliases)
-        res_rack = json.dumps(res_rack, indent=4)
-        print(res_rack)
-        # Redirecting the result to the tmp file
-        with open("/tmp/rack_info.txt", "w") as file:
-            file.write(res_rack + "\n")
-    else:
-        print(f"Failed to access the endpoint. Status code: {hsm_response.status_code}")
-        print("Response text:", hsm_response.text)
+    for xname in component_ids:
+        match = xname_regex.match(xname)
+        if match is None:
+            print_stderr(f"Component xname in HSM response has invalid format: {xname}")
+            sys.exit(1)
+        rack_id = match.group(1) # Extract "x3000" from "x3000c0s1b75n75"
+        # Set a sentinel to indicate that we have found the alias for this xname in SLS
+        found_alias = False
+        for sls_entry in sls_data:
+            if sls_entry["Xname"] != xname:
+                continue
+            for alias in sls_entry["ExtraProperties"]["Aliases"]:
+                if ncn_regex.match(alias) is None:
+                    continue
+                # That means this alias is of the form ncn-[msw]###,
+                # which is what we're looking for
+                res_rack[rack_id].append(alias)
+                found_alias=True
+                break
+            if found_alias:
+                break
+        if not found_alias:
+            print_stderr(f"Component {xname} has no alias in SLS of the form ncn-[msw]###")
+            sys.exit(1)
+
+    res_rack_str = json.dumps(res_rack, indent=4)
+    print(res_rack)
+    # Write the result to the tmp file
+    with open("/tmp/rack_info.txt", "w") as file:
+        file.write(res_rack + "\n")
 
 def main() -> None:
     """
@@ -108,29 +154,47 @@ def main() -> None:
     /tmp/rack_info.txt file to be consumed by zoning(k8s and ceph) functions.
     """
     if len(sys.argv) != 2:
-       logger.error("Usage: python3 rack_to_node_mapping.py <client_secret> ")
+       print_stderr("Usage: python3 rack_to_node_mapping.py <client_secret> ")
        sys.exit(1)
 
     # Fetch the keycloak token
     client_secret = sys.argv[1]
     token = token_fetch(client_secret)
     if token is None:
-        print("Failed to get the keycloak token")
+        print_stderr("Failed to get the keycloak token")
         sys.exit(1)
 
     # Parameters for sls
-    params = {'type': 'comptype_node'}
+    params = {"type": "comptype_node"}
     headers = {
         "Authorization": f"Bearer {token}",  # Add the token as a Bearer token
         "Accept": "application/json"         # Indicate you want a JSON response
     }
 
-    # Make the GET request to hsm and sls enpoints
-    hsm_response = requests.get(hsm_url, headers=headers)
-    sls_response = requests.get(sls_url, headers=headers, params=params)
+    # Make the GET request to hsm enpoint
+    with requests.get(hsm_url, headers=headers) as hsm_response:
+        # Check the response status
+        if hsm_response.status_code != 200:
+            print_stderr(f"HSM request failed. Status code: {hsm_response.status_code}")
+            print_stderr(f"Response text: {hsm_response.text}")
+            sys.exit(1)
+
+        # Decode the response body
+        hsm_data = hsm_response.json()
+
+    # Make the GET request to sls enpoint
+    with requests.get(sls_url, headers=headers, params=params) as sls_response:
+        # Check the response status
+        if sls_response.status_code != 200:
+            print_stderr(f"SLS request failed. Status code: {sls_response.status_code}")
+            print_stderr(f"Response text: {sls_response.text}")
+            sys.exit(1)
+
+        # Decode the response body
+        sls_data = sls_response.json()
 
     # Group the ncn nodes by their racks
-    rack_info(hsm_response,sls_response)
+    rack_info(hsm_data, sls_data)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary and Scope

This PR is open to fix several bad-path bugs in the `rack_to_node_mapping.py` script. Along the way, I also did some minor linting in places, to simplify code.

Here is the summary of the meaningful changes:

1. Previously the script referred to an undefined variable `logger`. I fixed that reference.
2. Previously the script did no validation to make sure that the xnames it was getting from HSM met the basic format that it expected. This is important because it assumes they will always have 5 characters and then a c, but it does not validate that. I have added a regular expression to validate that the beginning of the xname (up through the 'c' character) is as expected.
3. As part of adding the xname validation, I used a capturing group in the regular expression, so that the validation also grabbed the part of the xname that we wanted to extract. This simplified the procedure, and reduced the need for parsing the string with `cut` and array indexing.
4. I moved all of the HSM/SLS request business out into the main function, where the requests are actually being made. It did not make sense to have that as part of the function that is generating the output data file based on the response data. So now that function takes the response data as input.
5. As part of that move, I also separated the HSM and SLS requests, and serialized them. Previously it made both requests before it started looking at the responses. Now it fully deals with the HSM request and response (up through the point of decoding its body), and then does the same for the SLS request.
6. Also as part of that refactoring, I changed it so that each response was used as a context manager. It probably doesn't matter here (just like it doesn't matter too much when they do file IO to write the file), but it's best practice to do it, and doesn't change the logic.
7. Previously the script tried to JSON decode the HSM response body before checking the status of the HSM response. This is a problem because if the response failed, there's a good chance the JSON decode won't work, because the body may not be a valid JSON object. This PR changes it so that response status codes are checked first, before anything else is done with them.
8. Previously, after the script checked the HSM response status, if it found that it had failed, the script would just print an error message but exit successfully. This PR changes it so that this results in an error exit.
9. Previously, the script never checked the SLS response status code at all. This PR changes it so that both requests go through the same basic process -- make the request, check the status, exit if it's bad, otherwise decode the body.
10. Previously, the script did not make sure that the alias it found in SLS looked like what we expected. It could have been a blank string, or some weird value, and the script would happily write it to the data file without error. In this case, we know exactly the expected format of these aliases -- `ncn-m001`, `ncn-s002`, etc. So this PR adds a regular expression to make sure that we are finding the right alias.
11. Previously the script did not make sure that an alias was found for every NCN. If no alias was found for an NCN, then that NCN would just be omitted from the data file. That is not what should happen. This PR changes it so that for each NCN, if an alias is not found, it will fail.
12. Relatedly, previously if the SLS response happened to contain a duplicate entry for an NCN, then this would result in that NCN having 2 aliases written to the data file. This PR changes it so that after the alias is found for the NCN, it stops looking for more. 
13. Previously the script assumed that the alias we want will always be the first one listed in the SLS entry "aliases" list. I don't know if we ever see things in SLS with multiple aliases, or if there is some reason to assume the one we want will always be first. But in this case, where we know exactly what format the right alias will be in, it makes more sense to just scan the entire alias list to see if the one we want is in there. So that's what this PR does.

Although this is a long list of changes, each of them is pretty simple.

## Issues and Related PRs

* Resolves [CASM-5686](https://jira-pro.it.hpe.com:8443/browse/CASM-5686)

## Testing

Testing is underway. Will update when complete.

## Risks and Mitigations

Low risk -- the changes are simple and small.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

