### PR TITLE
CASMPET-7660: Make sbps_dns_srv_records.sh more verbose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.48.2] - 2025-08-20
+
+### Changed
+
+- CASMPET-7660: Changes to `sbps_dns_srv_records.sh` in `csm.sbps.dns_srv_records`
+  - Fail if `SYSTEM_NAME` or `SITE_DOMAIN` are not set
+  - Added echo statements role, to make it easier to debug in case of failure
+  - Remove `-s` and `-f` flags from `curl` calls, and add `-i` flag, so they will
+    give error messages and information on failure.
+
 ## [1.48.1] - 2025-08-19
 
 ### Fixed
@@ -805,7 +815,9 @@ RR Ansible plays for:
 
 - Ansible playbook for applying csm packages to Compute and Application nodes
 
-[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.48.1...HEAD
+[Unreleased]: https://github.com/Cray-HPE/csm-config/compare/1.48.2...HEAD
+
+[1.48.2]: https://github.com/Cray-HPE/csm-config/compare/1.48.1...1.48.2
 
 [1.48.1]: https://github.com/Cray-HPE/csm-config/compare/1.48.0...1.48.1
 

--- a/ansible/roles/csm.sbps.dns_srv_records/files/sbps_dns_srv_records.sh
+++ b/ansible/roles/csm.sbps.dns_srv_records/files/sbps_dns_srv_records.sh
@@ -25,7 +25,10 @@
 
 set -euo pipefail
 
+echo "Getting PDNS_API_KEY"
 PDNS_API_KEY=$(kubectl -n services get secret cray-powerdns-credentials -o jsonpath='{.data.pdns_api_key}' | base64 -d)
+
+echo "Getting PDNS_API"
 PDNS_API=$(kubectl -n services get svc cray-dns-powerdns-api -o jsonpath='{.spec.clusterIP}')
 
 hsn_srv_records=""
@@ -33,7 +36,21 @@ nmn_srv_records=""
 hsn_a_records=""
 nmn_a_records=""
 
+echo "Setting SITE_DOMAIN and SYSTEM_NAME from /etc/environment"
 eval "$(grep -e SITE_DOMAIN -e SYSTEM_NAME /etc/environment)"
+
+echo "SITE_DOMAIN: '${SITE_DOMAIN}'"
+echo "SYSTEM_NAME: '${SYSTEM_NAME}'"
+
+if [[ -z ${SITE_DOMAIN} ]]; then
+  echo "ERROR: SITE_DOMAIN is not set" 1>&2
+  exit 1
+fi
+
+if [[ -z ${SYSTEM_NAME} ]]; then
+  echo "ERROR: SYSTEM_NAME is not set" 1>&2
+  exit 1
+fi
 
 # - read each line from the file /tmp/hsn_nmn_info.txt passed on to this script
 #   to fetch Host Name, HSN and NMN IP's for each worker node.
@@ -41,32 +58,54 @@ eval "$(grep -e SITE_DOMAIN -e SYSTEM_NAME /etc/environment)"
 # - then create DNS SRV and A records based on the above data
 while read -r line; do
   # Strip out any '\r' characters
+  echo "Parsing line: '$line'"
+
+  echo "Removing '\r' characters from line"
   line=$(echo "$line" | tr -d '\r')
+
+  echo "Getting worker node name"
   ncn_worker_node=$(echo "$line" | awk -F ":" '{print $1}')
+
+  echo "Getting iSCSI server ID"
   iscsi_server_id="id-$(echo "$ncn_worker_node" | awk -F "-" '{print $2}' | awk '{print substr($1,2);}')"
 
+  echo "Getting hsn_ip"
   hsn_ip=$(echo "$line" | awk -F ":" '{print $2}') || true
+
+  echo "Getting nmn_ip"
   nmn_ip=$(echo "$line" | awk -F ":" '{print $3}')
 
   if [[ -n $hsn_ip ]]
   then
+    echo "Appending to hsn_srv_records"
     hsn_srv_records="$hsn_srv_records{\"content\": \"1 0 3260 iscsi-server-"${iscsi_server_id}.hsn.${SYSTEM_NAME}.${SITE_DOMAIN}."\",\"disabled\": false},"
 
+    echo "Appending to hsn_a_records"
     hsn_a_records="$hsn_a_records{\"comments\": [], \"name\": \"iscsi-server-"${iscsi_server_id}.hsn.${SYSTEM_NAME}.${SITE_DOMAIN}."\",\"changetype\":\"REPLACE\",\"records\":[{\"content\": \"${hsn_ip}\",\"disabled\": false}],\"ttl\": 3600,\"type\": \"A\"},"
   fi
 
+  echo "Appending to nmn_srv_records"
   nmn_srv_records="$nmn_srv_records{\"content\": \"1 0 3260 iscsi-server-"${iscsi_server_id}.nmn.${SYSTEM_NAME}.${SITE_DOMAIN}."\",\"disabled\": false},"
 
+  echo "Appending to nmn_a_records"
   nmn_a_records="$nmn_a_records{\"comments\": [], \"name\": \"iscsi-server-"${iscsi_server_id}.nmn.${SYSTEM_NAME}.${SITE_DOMAIN}."\",\"changetype\":\"REPLACE\",\"records\":[{\"content\": \"${nmn_ip}\",\"disabled\": false}],\"ttl\": 3600,\"type\": \"A\"},"
 done
 
 hsn_srv_records="${hsn_srv_records%?}"
-nmn_srv_records="${nmn_srv_records%?}"
-hsn_a_records="${hsn_a_records%?}"
-nmn_a_records="${nmn_a_records%?}"
+echo "hsn_srv_records: ${hsn_srv_records}"
 
+nmn_srv_records="${nmn_srv_records%?}"
+echo "nmn_srv_records: ${nmn_srv_records}"
+
+hsn_a_records="${hsn_a_records%?}"
+echo "hsn_a_records: ${hsn_a_records}"
+
+nmn_a_records="${nmn_a_records%?}"
+echo "nmn_a_records: ${nmn_a_records}"
+
+echo "Patch SRV records"
 # PATCH (update) DNS "SRV" records for HSN and NMN for all the worker nodes
-curl -sf -X PATCH -H "X-API-Key: ${PDNS_API_KEY}" "http://${PDNS_API}:8081/api/v1/servers/localhost/zones/${SYSTEM_NAME}.${SITE_DOMAIN}" -d'
+curl -i -X PATCH -H "X-API-Key: ${PDNS_API_KEY}" "http://${PDNS_API}:8081/api/v1/servers/localhost/zones/${SYSTEM_NAME}.${SITE_DOMAIN}" -d'
 {
   "rrsets": [
     {
@@ -95,7 +134,8 @@ curl -sf -X PATCH -H "X-API-Key: ${PDNS_API_KEY}" "http://${PDNS_API}:8081/api/v
 if [[ -n $hsn_a_records ]]
 then
   # PATCH (update) DNS  "A" records for HSN for all the worker nodes
-curl -sf -X PATCH -H "X-API-Key: ${PDNS_API_KEY}" "http://${PDNS_API}:8081/api/v1/servers/localhost/zones/hsn.${SYSTEM_NAME}.${SITE_DOMAIN}" -d'
+  echo "Patch HSN A records"
+  curl -i -X PATCH -H "X-API-Key: ${PDNS_API_KEY}" "http://${PDNS_API}:8081/api/v1/servers/localhost/zones/hsn.${SYSTEM_NAME}.${SITE_DOMAIN}" -d'
   {
     "rrsets": [
       '"${hsn_a_records}"'
@@ -104,9 +144,12 @@ curl -sf -X PATCH -H "X-API-Key: ${PDNS_API_KEY}" "http://${PDNS_API}:8081/api/v
 fi
 
 # PATCH (update) DNS  "A" records for NMN for all the worker nodes
-curl -sf -X PATCH -H "X-API-Key: ${PDNS_API_KEY}" "http://${PDNS_API}:8081/api/v1/servers/localhost/zones/nmn.${SYSTEM_NAME}.${SITE_DOMAIN}" -d'
+echo "Patch NMN A records"
+curl -i -X PATCH -H "X-API-Key: ${PDNS_API_KEY}" "http://${PDNS_API}:8081/api/v1/servers/localhost/zones/nmn.${SYSTEM_NAME}.${SITE_DOMAIN}" -d'
 {
   "rrsets": [
     '"${nmn_a_records}"'
   ]
 }'
+
+echo DONE


### PR DESCRIPTION
## Summary and Scope

This PR makes 3 changes to the `sbps_dns_srv_records.sh` script:

1. Prior to this PR, the script made no checks to ensure that `SYSTEM_NAME` or `SITE_DOMAIN` are set to non-empty values. If they are blank, it will either cause the script to fail, or (worse) the script would pass but not actually update the DNS records correctly. This PR changes it so that it checks if these are blank, and if they are, it will exit with an appropriate error message.
2. Numerous `echo` statements added, so that the output of the script shows what is happening. This is important because prior to this PR, when the script fails, the only information you have to go on is whatever error message was given by the thing that caused it to fail. This may not be very descriptive; it may not be obvious which specific part of the script was running when the failure happened.
3. Removed the `-s` and `-f` flags from the `curl` calls, as these cause it to suppress all output, including error output. We don't need to run them with the verbose flag, but add the `-i` flag, so we get HTTP status codes in the output. We do want them to give us output that gives us a clue about why they failed. Yes, this also means they will be giving output on success as well, but by default none of this output will show up in the Ansible logs when the script passes. The only times it will show up is when the script fails or if the Ansible verbosity is increased from default.

## Issues and Related PRs

* Resolves [CASMPET-7660](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7660)
* Implemented to help debug of problems like [CASMTRIAGE-8636](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8636)
* This is only a stopgap until [CASMPET-7661](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7661) is implemented.

## Testing

I updated the CFS configurations on `fanta` with these changes, cleared the iSCSI layers from their statuses, and confirmed that the script still works as intended.

I then did the same thing with the Ansible verbosity increased, and verified that the script is giving the expected verbose output.

## Risks and Mitigations

Very low risk. The additional output does not change the behavior of the script. The extra checks for the 2 variables being unset are very simple checks, and it is definitely better to have the script fail at that point rather than later (or not at all).

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

