### PR TITLE
CASMCMS-9637: Update zypper-docker-build.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Dependencies
 - CASMCMS-9638: Update `zypper-refresh-patch-clean.sh` to ensure it applies all necessary patches
+- CASMCMS-9637: Update `zypper-docker-build.sh`
+    - Include SLE LTSS zypper repositories, in order to pick up CVE fixes
+    - Create single version across the github repos which use it
 
 ## [1.50.3] - 2026-01-16
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2024, 2026 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -23,7 +23,7 @@
 #
 # Dockerfile for importing CSM content into gitea, to be used with CFS
 
-FROM artifactory.algol60.net/registry.suse.com/suse/sle15:15.6 as product-content-base
+FROM artifactory.algol60.net/registry.suse.com/suse/sle15:15.6 AS product-content-base
 WORKDIR /
 
 ARG SP=6
@@ -38,7 +38,9 @@ COPY zypper-docker-build.sh /
 # The above script calls the following script, so we need to copy it as well
 COPY zypper-refresh-patch-clean.sh /
 RUN --mount=type=secret,id=ARTIFACTORY_READONLY_USER --mount=type=secret,id=ARTIFACTORY_READONLY_TOKEN \
-    ./zypper-docker-build.sh && \
+    ./zypper-docker-build.sh \
+        csm-ssh-keys-roles-${CSM_SSH_KEYS_VERSION} \
+        --lock csm-ssh-keys-roles && \
     rm /zypper-docker-build.sh /zypper-refresh-patch-clean.sh
 
 FROM artifactory.algol60.net/csm-docker/stable/cf-gitea-import:@CF_GITEA_IMPORT_VERSION@ as cf-gitea-import-base

--- a/zypper-docker-build.sh
+++ b/zypper-docker-build.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2026 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -31,12 +31,65 @@
 # 1. Following variables have been set in the Dockerfile: SP ARCH CSM_SSH_KEYS_VERSION
 # 2. zypper-refresh-patch-clean.sh script has also been copied into the current directory
 
+# Usage:
+# zypper-docker-build.sh [<package1> [<package2> ...]]
+#                        [--lock <package x> [<package y> ...]]
+#                        [--remove <package a> [<package b> ...]]
+# 1. Adds the repos
+# 2. Installs the specified packages (if any)
+# 3. Removes the specified packages (if any)
+# 4. Locks the specified packages (if any)
+# 5. Applies curl workaround, if necessary
+# 6. Applies security patches (if any)
+# 7. Removes repos
+
 # Based in part on: https://github.com/Cray-HPE/uai-images/blob/main/uai-images/broker_uai/zypper.sh
 
 set -e +xv
 trap "rm -rf /root/.zypp" EXIT
 
-# Get artifactory credentials and use them to set the csm-rpms stable sles15sp$SP repository URI
+INSTALL_LIST=()
+LOCK_LIST=()
+REMOVE_LIST=()
+# First handle packages to be installed, since they have to be listed first
+# if they are present
+
+# Consume all arguments until we reach the end of the
+# arguments or until we hit an argument beginning with --
+while [[ $# -gt 0 && ${1:0:2} != -- ]]; do
+    INSTALL_LIST+=( "$1" )
+    shift
+done
+
+# Now process the remaining arguments, if any
+while [[ $# -gt 0 ]]; do
+    op="$1"
+    shift
+    case "$op" in
+        "--lock")
+            # Consume all subsequent arguments until we reach the end of the
+            # arguments or until we hit an argument beginning with --
+            while [[ $# -gt 0 && ${1:0:2} != -- ]]; do
+                LOCK_LIST+=( "$1" )
+                shift
+            done
+            ;;
+        "--remove")
+            # Consume all subsequent arguments until we reach the end of the
+            # arguments or until we hit an argument beginning with --
+            while [[ $# -gt 0 && ${1:0:2} != -- ]]; do
+                REMOVE_LIST+=( "$1" )
+                shift
+            done
+            ;;
+        *)
+            echo "USAGE ERROR: Invalid argument: $op" 1>&2
+            exit 1
+            ;;
+    esac
+done
+
+# Get artifactory credentials and use them to set the repository URLs
 ARTIFACTORY_USERNAME=$(test -f /run/secrets/ARTIFACTORY_READONLY_USER && cat /run/secrets/ARTIFACTORY_READONLY_USER)
 ARTIFACTORY_PASSWORD=$(test -f /run/secrets/ARTIFACTORY_READONLY_TOKEN && cat /run/secrets/ARTIFACTORY_READONLY_TOKEN)
 CREDS=${ARTIFACTORY_USERNAME:-}
@@ -48,11 +101,65 @@ SLES_MIRROR_URL="https://${CREDS}@artifactory.algol60.net/artifactory/sles-mirro
 SLES_PRODUCTS_URL="${SLES_MIRROR_URL}/Products"
 SLES_UPDATES_URL="${SLES_MIRROR_URL}/Updates"
 
-function add_zypper_repos {
-    local label
+function run_cmd_retry
+{
+    local num rc
+    num=0
+    while [[ $num -lt 5 ]]; do
+        [[ $num -eq 0 ]] || sleep 5
+        echo "# $*"
+        "$@" && return 0 || rc=$?
+        echo "Command failed with rc $rc"
+        let num+=1
+    done
+    echo "Command failed even after retries"
+    return $rc
+}
+
+function add_zypper_product_repo {
+    local label repo_sp
     label=$1
-    zypper --non-interactive ar "${SLES_PRODUCTS_URL}/SLE-${label}/15-SP${SP}/${ARCH}/product/?auth=basic" "sles15sp${SP}-${label}-product"
-    zypper --non-interactive ar "${SLES_UPDATES_URL}/SLE-${label}/15-SP${SP}/${ARCH}/update/?auth=basic" "sles15sp${SP}-${label}-update"
+    if [[ $# -eq 2 ]]; then
+        repo_sp=$2
+    else
+        repo_sp=${SP}
+    fi
+    run_cmd_retry zypper --non-interactive ar "${SLES_PRODUCTS_URL}/SLE-${label}/15-SP${repo_sp}/${ARCH}/product/?auth=basic" "sles15sp${repo_sp}-${label}-product"
+}
+
+function add_zypper_update_repo {
+    local label repo_sp
+    label=$1
+    if [[ $# -eq 2 ]]; then
+        repo_sp=$2
+    else
+        repo_sp=${SP}
+    fi
+    run_cmd_retry zypper --non-interactive ar "${SLES_UPDATES_URL}/SLE-${label}/15-SP${repo_sp}/${ARCH}/update/?auth=basic" "sles15sp${repo_sp}-${label}-update"
+}
+
+function add_zypper_repos {
+    local label repo_sp
+    label=$1
+    if [[ $# -eq 2 ]]; then
+        repo_sp=$2
+    else
+        repo_sp=${SP}
+    fi
+    add_zypper_product_repo "${label}" "${repo_sp}"
+    add_zypper_update_repo "${label}" "${repo_sp}"
+}
+
+function remove_zypper_repos {
+    local label repo_sp
+    label=$1
+    if [[ $# -eq 2 ]]; then
+        repo_sp=$2
+    else
+        repo_sp=${SP}
+    fi
+    run_cmd_retry zypper --non-interactive rr "sles15sp${repo_sp}-${label}-product"
+    run_cmd_retry zypper --non-interactive rr "sles15sp${repo_sp}-${label}-update"
 }
 
 if [[ ${SP} -lt 5 ]]; then
@@ -61,13 +168,15 @@ if [[ ${SP} -lt 5 ]]; then
     exit 1
 fi
 
-zypper --non-interactive rr --all
-zypper --non-interactive clean -a
+run_cmd_retry zypper --non-interactive rr --all
+run_cmd_retry zypper --non-interactive clean -a
+
 for MODULE in Basesystem Certifications Containers Desktop-Applications Development-Tools HPC Legacy Packagehub-Subpackages \
               Public-Cloud Python3 Server-Applications Web-Scripting
 do
     add_zypper_repos "Module-${MODULE}"
 done
+
 PRODUCTS="SLES WE"
 if [[ ${SP} -lt 6 ]]; then
     # HPC is deprecated in SP6, but we want to include it for previous SPs
@@ -76,14 +185,81 @@ fi
 for PRODUCT in $PRODUCTS; do
     add_zypper_repos "Product-${PRODUCT}"
 done
-zypper --non-interactive ar --no-gpgcheck "${CSM_SLES_REPO_URL}" csm-sles
-zypper --non-interactive ar --no-gpgcheck "${CSM_NOOS_REPO_URL}" csm-noos
-zypper --non-interactive --gpg-auto-import-keys refresh
-zypper --non-interactive in -f --no-confirm csm-ssh-keys-roles-${CSM_SSH_KEYS_VERSION}
-# Lock the version of csm-ssh-keys-roles, just to be certain it is not upgraded inadvertently somehow later
-zypper --non-interactive al csm-ssh-keys-roles
+
+# SP < 7 also have LTSS update repos
+# Once SP 7 goes LTSS, this should be updated accordingly
+if [[ $SP -lt 7 ]]; then
+    add_zypper_update_repo Product-SLES "${SP}-LTSS"
+fi
+
+run_cmd_retry zypper --non-interactive ar --no-gpgcheck "${CSM_SLES_REPO_URL}" csm-sles
+run_cmd_retry zypper --non-interactive ar --no-gpgcheck "${CSM_NOOS_REPO_URL}" csm-noos
+run_cmd_retry zypper --non-interactive --gpg-auto-import-keys refresh
+
+if [[ ${#INSTALL_LIST[@]} -gt 0 ]]; then
+    run_cmd_retry zypper --non-interactive in -f --no-confirm "${INSTALL_LIST[@]}"
+fi
+
+if [[ ${#REMOVE_LIST[@]} -gt 0 ]]; then
+    run_cmd_retry zypper --non-interactive rm --no-confirm "${REMOVE_LIST[@]}"
+fi
+
+if [[ ${#LOCK_LIST[@]} -gt 0 ]]; then
+    run_cmd_retry zypper --non-interactive al "${LOCK_LIST[@]}"
+fi
+
+#############################################################################
+# curl bug workaround
+#############################################################################
+
+# There is a bug in curl that breaks some operations
+# https://github.com/curl/curl/issues/13229
+# We know that it is not yet present in curl v8.5 and is fixed in v8.8.
+# The current SP6 repos don't have a version without this problem. So we add
+# an SP5 repo to pull in a good version of it
+
+function apply_curl_bug_workaround
+{
+    local S
+    # First try to install a newer version, where the bug is fixed, using
+    # just our current repos
+    if ! zypper --non-interactive in --force-resolution --no-confirm --no-recommends 'curl>=8.8' ; then
+
+        # Failing that, add in the earlier repos
+
+        # Add in the earlier repos (SP5+)
+        S=5
+        while [[ $S -lt $SP ]]; do
+            add_zypper_repos Module-Basesystem "$S"
+            let S+=1
+        done
+        run_cmd_retry zypper --non-interactive --gpg-auto-import-keys refresh
+
+        # Now try again to install the newer version, where the bug is fixed.
+        # Failing that, try to install the older version, before the bug existed.
+        zypper --non-interactive in --force-resolution --no-confirm --no-recommends 'curl>=8.8'  || \
+            zypper --non-interactive in --force-resolution --no-confirm --oldpackage --no-recommends 'curl<8.6'
+
+        # Remove the backlevel repos so we don't pull other images from them
+        S=5
+        while [[ $S -lt $SP ]]; do
+            remove_zypper_repos Module-Basesystem "$S"
+            let S+=1
+        done
+    fi
+
+    # And then lock the curl version so we don't change the version later
+    run_cmd_retry zypper --non-interactive al curl
+}
+
+# Only need to apply the curl bug workaround if curl is installed
+if rpm -q curl ; then
+    apply_curl_bug_workaround
+fi
+#############################################################################
+
 # Apply security patches (this script also does a zypper clean)
 ./zypper-refresh-patch-clean.sh
 # Remove all repos & scrub the zypper directory 
-zypper --non-interactive rr --all
+run_cmd_retry zypper --non-interactive rr --all
 rm -f /etc/zypp/repos.d/*


### PR DESCRIPTION
This makes no changes to csm-config code itself. See https://github.com/Cray-HPE/console-node/pull/130 for full details on the shared build script being changed by this PR.

In the case of csm-config, there are no existing CVEs that this resolves. It just helps avoid future ones, and ensures that this build script is common across the repos which share it.